### PR TITLE
Add pyup configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 generated
+
+# Pycharm
+.idea

--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,5 +1,8 @@
 # Configuration for the PyUp update bot
 
+# Make one pull request per month
+schedule: "every month"
+
 # Do not search for requirement files...
 search: False
 

--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,0 +1,11 @@
+# Configuration for the PyUp update bot
+
+# Do not search for requirement files...
+search: False
+
+# ... we specify them by hand:
+requirements:
+  - conda_xnt.yml
+      # update all dependencies and pin them
+      update: all
+      pin: True

--- a/conda_xnt.yml
+++ b/conda_xnt.yml
@@ -1,6 +1,6 @@
 dependencies:
   - astropy
-  - boost=1.60.0
+  - boost=1.60.0   # pyup: ignore
   - boto
   - cython
   - dask
@@ -18,7 +18,7 @@ dependencies:
   - pandas
   - pandoc
   - pip
-  - python=3.6
+  - python=3.6   # pyup: ignore
   - scikit-learn
   - scipy
   - sphinx


### PR DESCRIPTION
This adds a yml file that configures the PyUp update bot for this repository. After this is merged and we close #3, this should generate automatic pull requests to pin our dependencies and keep them up to date. By default it will do this once a month. From the TravisCI tests status, we can see if everything still works. If so, we can merge the PR when we release a new container version.

I added some directives to conda_xnt to let pyup ignore the boost and python versions. We'll have to update these manually if/when we want to do this.

See also https://github.com/AxFoundation/strax/issues/197.