### PR TITLE
Update straxen to v0.3.2

### DIFF
--- a/create-env
+++ b/create-env
@@ -5,7 +5,7 @@
 # versions in this release
 
 admix_version=0.2
-straxen_version=0.3.1
+straxen_version=0.3.2
 
 #######################################################################
 


### PR DESCRIPTION
This updates straxen to v0.3.2. 

I'd propose I merge this tomorrow morning (Europe time), then replace the data on dali with the 0.3.2 reprocessed versions when not many people are working.

@rynge After this, perhaps it would be a good time to make our first versioned environment?