### PR TITLE
Move most dependencies to pip

### DIFF
--- a/conda_xnt.yml
+++ b/conda_xnt.yml
@@ -35,6 +35,7 @@ dependencies:
     - psutil==5.6.4     # Strax dependency
     - tables            # pytables, necessary for pandas hdf5 i/o
     - pymongo==3.9.0
+    - pytest
     - scikit-learn
     - scipy==1.3.1
     - sphinx

--- a/conda_xnt.yml
+++ b/conda_xnt.yml
@@ -1,33 +1,45 @@
 dependencies:
-  - astropy
-  - boost=1.60.0   # pyup: ignore
-  - boto
-  - cython
-  - dask
-  - datashader
-  - flake8
-  - future
-  - jupyter
-  - jupyterlab
+  - boost=1.60.0
   - graphviz
-  - holoviews
-  - iminuit
-  - matplotlib
   - nb_conda
   - nodejs
-  - numba>=0.44
-  - numpy
-  - pandas
-  - pandoc
   - pip
-  - pytables
-  - python=3.6   # pyup: ignore
-  - scikit-learn
-  - scipy
-  - sphinx
-  - tensorflow
-  - tqdm
+  - python=3.6
   - pip:
+    - astropy
+    - blosc==1.8.1       # Strax dependency
+    - boto
+    - boto3==1.10.8      # Strax dependency
     - boltons
+    - bokeh
+    - cython
+    - dask
+    - datashader
+    - dill==0.3.1.1      # Strax dependency
+    - future
+    - flake8
+    - flamedisx
     - hypothesis
+    - jupyter
+    - jupyterlab
+    - holoviews
+    - iminuit
+    - lz4==2.2.1        # Strax dependency
+    - matplotlib
+    - multihist
     - nbsphinx
+    - numba==0.46.0
+    - numpy==1.17.3
+    - pandas==0.25.3
+    - pandoc
+    - psutil==5.6.4     # Strax dependency
+    - pytables          # Necessary for pandas hdf5 i/o
+    - pymongo==3.9.0
+    - scikit-learn
+    - scipy==1.3.1
+    - sphinx
+    - strax
+    - tensorflow==2.0.0
+    - tensorflow_probability
+    - tqdm==4.37.0
+    - zstd==1.4.3.2     # Strax dependency

--- a/conda_xnt.yml
+++ b/conda_xnt.yml
@@ -33,7 +33,7 @@ dependencies:
     - pandas==0.25.3
     - pandoc
     - psutil==5.6.4     # Strax dependency
-    - pytables          # Necessary for pandas hdf5 i/o
+    - tables            # pytables, necessary for pandas hdf5 i/o
     - pymongo==3.9.0
     - scikit-learn
     - scipy==1.3.1

--- a/create-env
+++ b/create-env
@@ -75,18 +75,12 @@ rm -f ${target_dir}/anaconda/pkgs/rope-0.11.0-py37_0/info/LICENSE.txt
 announce "Activating Anaconda environment"
 source $target_dir/anaconda/bin/activate ${env_name}
 
-announce "Installing non-grid XENON software"
 jupyter labextension install @pyviz/jupyterlab_pyviz   # for waveform display in jupyterlab
-pip install tensorflow==2.0.0-beta1          # Overwrites conda-installed version. Installing 2 directly via pip does not work.
-                                             # NB: After this conda installs are likey to fail since env is now inconsistent!
-pip install strax straxen==${straxen_version} flamedisx
+announce "Installing non-grid XENON software"
+pip install straxen==${straxen_version}
 pip install git+https://github.com/XENONnT/utilix.git
 pip install git+https://github.com/XENONnT/WFSim.git
 pip install git+https://github.com/XENONnT/admix.git@v${admix_version}
-
-# Extra flamedisx requirements
-pip install gast==0.2.2
-pip install tensorflow_probability==0.8.0-rc0
 
 # gfal2
 announce "Installing GFAL2"


### PR DESCRIPTION
This moves most dependencies to the pip section of the conda yml. If this works, pyup will be able to see them and we will then be able to auto-pin and auto-update their versions.