### PR TITLE
Add default proxy to create-env setup script

### DIFF
--- a/create-env
+++ b/create-env
@@ -199,7 +199,7 @@ fi
 
 # site-specific stuff
 for space in /project2/lgrandi/grid_proxy /xenon/grid_proxy; do
-    if [[ -d $space ]]; then
+    if [ -d $space ]; then
         export X509_USER_PROXY=${space}/xenon_service_proxy
     fi
 done

--- a/create-env
+++ b/create-env
@@ -197,6 +197,13 @@ if [ "x\$X509_CERT_DIR" = "x" ]; then
     export X509_CERT_DIR=/etc/grid-security/certificates
 fi
 
+# site-specific stuff
+for space in /project2/lgrandi/grid_proxy /xenon/grid_proxy; do
+    if [[ -d $space ]]; then
+        export X509_USER_PROXY=${space}/xenon_service_proxy
+    fi
+done
+
 EOF
 
 announce "Running tests"


### PR DESCRIPTION
This PR adds a default path to an X509 proxy based on which site it's running at (though usually will be Midway). Then e.g. rucio commands should require no further setup for the general user on Midway. 