### PR TITLE
Update strax to v0.10.1 and straxen to v0.7.1

### DIFF
--- a/create-env
+++ b/create-env
@@ -9,7 +9,7 @@ gfal2_bindings_versions=develop # project is not releasing often enough
 gfal2_util_version=master # project is not releasing often enough
 rucio_version=1.21.7
 # admix_version=0.2.3
-straxen_version=0.6.0
+straxen_version=0.7.2
 
 #######################################################################
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ pytest==5.4.1
 scikit-learn==0.22.2.post1
 scipy==1.4.1
 sphinx==2.4.4
-strax==0.10.1
+strax==0.10.2
 tensorflow==2.1.0
 tensorflow_probability==0.9.0
 tqdm==4.43.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ pytest==5.4.1
 scikit-learn==0.22.2.post1
 scipy==1.4.1
 sphinx==2.4.4
+strax==0.10.1
 tensorflow==2.1.0
 tensorflow_probability==0.9.0
 tqdm==4.43.0


### PR DESCRIPTION
I reprocessed the converted XENON1T data, so we should now be able to update strax and straxen without disruption.

Actually, I accidentally removed the strax version pin in https://github.com/XENONnT/base_environment/commit/0f4ce7cd094fe7d2544f481ddfea2a2779f937c9... so strax is already up to date :-)