### PR TITLE
Auto-source the anaconda environment

### DIFF
--- a/create-env
+++ b/create-env
@@ -212,7 +212,7 @@ EOF
 announce "Adding 50-xenon.sh"
 
 # this will be sourced when entering the container
-cat > .singularity.d/env/50-xenon.sh <<EOF
+cat > /.singularity.d/env/50-xenon.sh <<EOF
 #!/bin/bash
 if [ "x\$XENON_SOURCE" = "x" ]; then
     export XENON_SOURCE=1

--- a/create-env
+++ b/create-env
@@ -208,6 +208,20 @@ done
 
 EOF
 
+announce "Adding 50-xenon.sh"
+
+# this will be sourced when entering the container
+cat > .singularity.d/env/50-xenon.sh <<EOF
+#!/bin/bash
+if [ "x\$XENON_SOURCE" = "x" ]; then
+    export XENON_SOURCE=1
+fi
+
+if [ \$XENON_SOURCE -eq 1 ]; then
+    source ${target_dir}/setup.sh
+fi
+EOF
+
 announce "Running tests"
 . ${target_dir}/setup.sh
 # gfal2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ boltons==20.1.0
 bokeh==2.0.1
 cython==0.29.16
 dask==2.13.0
-cython==0.29.15
 datashader==0.10.0
 dill==0.3.1.1      # Strax dependency
 distributed===2.13.0     # Dask extension


### PR DESCRIPTION
This PR allows for the anaconda environment to be source automatically when entering the container, which is by far the most common use-case. If e.g. you are developing something and want a clean environment, just set the env variable `export XENON_SOURCE=0` before entering the container, or you could do it in one line:

```
XENON_SOURCE=0 singularity shell ...
```
If `XENON_SOURCE` is not set, it will be set equal to 1 in `.singularity.d/env/50-xenon.sh` and so the default mode is to auto-source. 
