### PR TITLE
Adding pyarrow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ numpy==1.18.4
 pandoc==1.0.2
 psutil==5.7.0     # Strax dependency
 tables==3.6.1     # pytables, necessary for pandas hdf5 i/o
+pyarrow==0.17.1   # Necessary for pandas feather i/o
 pymongo==3.10.1
 pytest==5.4.2
 scikit-learn==0.23.1


### PR DESCRIPTION
Pandas `to_feather()` currently returns "ImportError: Missing optional dependency 'pyarrow'.  Use pip or conda to install pyarrow.".
Adding `pyarrow` here should fix the issue.