### PR TITLE
Upgrade to python 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM opensciencegrid/osgvo-el7
 
 LABEL opensciencegrid.name="XENONnT"
-LABEL opensciencegrid.description="Base software environment for XENONnT, including Python 3.6 and data management tools"
+LABEL opensciencegrid.description="Base software environment for XENONnT, including Python 3.8 and data management tools"
 LABEL opensciencegrid.url="http://www.xenon1t.org/"
 LABEL opensciencegrid.category="Project"
 LABEL opensciencegrid.definition_url="https://github.com/XENONnT/base_environment"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/XENONnT/base_environment.svg?branch=master)](https://travis-ci.org/XENONnT/base_environment)
 [![Dependabot](https://api.dependabot.com/badges/status?host=github&repo=XENONnT/base_environment)](https://app.dependabot.com/accounts/XENONnT/projects/134273)
 
-Base software environment for XENONnT, including Python 3.6 and data management tools.
+Base software environment for XENONnT, including Python 3.8 and data management tools.
 
 Please see [this page on the XENON wiki](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon%3Axenonnt%3Acomputing%3Abaseenvironment) for more details.
 

--- a/conda_xnt.yml
+++ b/conda_xnt.yml
@@ -4,6 +4,6 @@ dependencies:
   - nb_conda
   - nodejs
   - pip
-  - python=3.6
+  - python=3.8
   - pip:
     - -r file:requirements.txt

--- a/conda_xnt.yml
+++ b/conda_xnt.yml
@@ -1,5 +1,5 @@
 dependencies:
-  - boost=1.60.0
+  - boost
   - graphviz
   - nb_conda
   - nodejs

--- a/conda_xnt.yml
+++ b/conda_xnt.yml
@@ -1,5 +1,5 @@
 dependencies:
-  - boost
+  - boost  # will install correct version in create-env
   - graphviz
   - nb_conda
   - nodejs

--- a/create-env
+++ b/create-env
@@ -12,7 +12,7 @@ rucio_version=1.21.7
 strax_version=0.12.1
 straxen_version=0.10.1
 boost_version=1.60.0
-
+python_version=3.8
 
 #######################################################################
 
@@ -112,9 +112,9 @@ git clone https://gitlab.cern.ch/dmc/gfal2-bindings.git
 cd gfal2-bindings
 git checkout $gfal2_bindings_version
 perl -p -i -e "s;.*\\\${Boost_LIBRARYDIR};            \"${target_dir}/anaconda/envs/${env_name}/lib\";" CMakeLists.txt
-cmake -DPYTHON_EXECUTABLE=${target_dir}/anaconda/envs/${env_name}/bin/python3.6 \
-      -DPYTHON_EXECUTABLE_3=${target_dir}/anaconda/envs/${env_name}/bin/python3.6 \
-      -DPYTHON_EXECUTABLE_3.6=${target_dir}/anaconda/envs/${env_name}/bin/python3.6 \
+cmake -DPYTHON_EXECUTABLE=${target_dir}/anaconda/envs/${env_name}/bin/python$python_version \
+      -DPYTHON_EXECUTABLE_3=${target_dir}/anaconda/envs/${env_name}/bin/python$python_version \
+      -DPYTHON_EXECUTABLE_$python_version=${target_dir}/anaconda/envs/${env_name}/bin/python$python_version \
       -DBOOST_ROOT=${target_dir}/anaconda/envs/${env_name} \
       -DSKIP_DOC=TRUE -DSKIP_TESTS=TRUE
 make
@@ -128,7 +128,7 @@ git clone https://gitlab.cern.ch/dmc/gfal2-util.git
 cd gfal2-util/
 git checkout $gfal2_util_version
 perl -p -i -e 's;src/;src_py3/;g' setup.py
-python3.6 setup.py install --prefix=${target_dir}/anaconda/envs/${env_name}
+python$python_version setup.py install --prefix=${target_dir}/anaconda/envs/${env_name}
 cd ${target_dir}
 rm -rf gfal2-util
 
@@ -165,15 +165,15 @@ client_x509_proxy = \$X509_USER_PROXY
 request_retries = 3
 EOF
 
-# boost
-announce "Installing boost version"
-git clone https://github.com/boostorg/boost.git
-cd boost
-git checkout boost-$boost_version
-./bootstrap.sh --prefix=${target_dir}/anaconda/envs/${env_name}
-./b2 install
-cd ${target_dir}
-rm -rf boost
+## boost
+#announce "Installing boost version"
+#git clone https://github.com/boostorg/boost.git
+#cd boost
+#git checkout boost-$boost_version
+#./bootstrap.sh --prefix=${target_dir}/anaconda/envs/${env_name}
+#./b2 install
+#cd ${target_dir}
+#rm -rf boost
 
 announce "Adding setup.sh"
 

--- a/create-env
+++ b/create-env
@@ -11,6 +11,7 @@ rucio_version=1.21.7
 # admix_version=0.2.3
 strax_version=0.12.1
 straxen_version=0.10.1
+boost_version=1.60.0
 
 
 #######################################################################
@@ -163,6 +164,16 @@ client_key = \$X509_USER_PROXY
 client_x509_proxy = \$X509_USER_PROXY
 request_retries = 3
 EOF
+
+# boost
+announce "Installing boost version"
+git clone https://github.com/boostorg/boost.git
+cd boost
+git checkout boost-$boost_version
+./bootstrap.sh --prefix=${target_dir}/anaconda/envs/${env_name}
+./b2 install
+cd ${target_dir}
+rm -rf boost
 
 announce "Adding setup.sh"
 

--- a/labels.json
+++ b/labels.json
@@ -1,6 +1,6 @@
 {
     "opensciencegrid.name": "XENONnT",
-    "opensciencegrid.description": "Base software environment for XENONnT, including Python 3.6 and data management tools",
+    "opensciencegrid.description": "Base software environment for XENONnT, including Python 3.8 and data management tools",
     "opensciencegrid.url": "http://www.xenon1t.org/",
     "opensciencegrid.category": "Project",
     "opensciencegrid.definition_url": "https://github.com/XENONnT/base_environment"


### PR DESCRIPTION
**Switch to python 3.8 for increased strax-performance.** 

A while back I[ did some tests ](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:dsg:daq:eb_speed_tests#python_version) for bench-marking strax performance on the event builders. Python 3.8 was ~20% faster than python 3.6. With this PR I'd like to start a discussion wither this could be an option of the base environment as well. (I'm not sure if I changed all the appropriate places yet so please review carefully.)

If needed, I can repeat the tests in the above-mentioned links.

Commit history 
- 745b625 -> failed due to the conflicts between python and boost
- b78ffae  -> disabled boost requirement (I don't know if this is a good idea)