### PR TITLE
Move strax(en) versions to requirements

### DIFF
--- a/create-env
+++ b/create-env
@@ -9,8 +9,6 @@ gfal2_bindings_version=ac5cd70bc0654cd5b72cc01085eeaafb469b9622 # project is not
 gfal2_util_version=1.5.4 # reset to master since project is not releasing often enough
 rucio_version=1.21.7
 # admix_version=0.2.3 # commented out to use master
-strax_version=0.12.4
-straxen_version=0.12.3
 
 #######################################################################
 
@@ -82,10 +80,6 @@ source $target_dir/anaconda/bin/activate ${env_name}
 
 jupyter labextension install @pyviz/jupyterlab_pyviz   # for waveform display in jupyterlab
 announce "Installing non-grid XENON software"
-pip install strax==${strax_version}
-# Utilix before straxen!
-pip install git+https://github.com/XENONnT/utilix.git
-pip install straxen==${straxen_version}
 pip install git+https://github.com/XENONnT/WFSim.git
 pip install git+https://github.com/XENONnT/admix.git
 
@@ -269,14 +263,16 @@ announce "Running tests"
 # gfal2
 python -c 'import gfal2'
 # Strax
+strax_version=`python -c "import strax; print(strax.__version__)"`
 git clone --single-branch --branch v$strax_version https://github.com/AxFoundation/strax.git
 pytest strax || { echo 'strax tests failed' ; exit 1; }
 rm -r strax
+
 # Straxen
+straxen_version=`python -c "import straxen; print(straxen.__version__)"`
 git clone --single-branch --branch v$straxen_version https://github.com/XENONnT/straxen.git
 pytest straxen || { echo 'straxen tests failed' ; exit 1; }
 rm -r straxen
-
 
 announce "All done!"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,6 +45,6 @@ tables==3.6.1     # pytables, necessary for pandas hdf5 i/o
 tensorflow==2.3.1
 tensorflow_probability==0.11.1
 tqdm==4.54.0
-utilix==0.3.1       # dependency for straxen, admix
+utilix==0.3.2       # dependency for straxen, admix
 zstd==1.4.5.1     # Strax dependency
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,8 @@ pytest==6.1.2
 torch==1.7.0     # Strax dependency
 scikit-learn==0.23.2
 scipy==1.5.4
+strax==0.12.4
+straxen==0.12.3
 snakeviz==2.1.0
 sphinx==3.3.1
 tables==3.6.1     # pytables, necessary for pandas hdf5 i/o


### PR DESCRIPTION
To streamline the setup of the env, put strax and straxen in requirements. 