### PR TITLE
bump nestpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ matplotlib==3.3.3
 memory_profiler==0.58.0
 multihist==0.6.3
 nbsphinx==0.8.0
-nestpy==1.3.0     # WFsim dependency
+nestpy==1.4.1     # WFsim dependency
 numba==0.51.2
 numpy==1.18.5
 pandoc==1.0.2


### PR DESCRIPTION
Had problems with the dependabot PR so making a new one. This bumps nestpy to 1.4.1