### PR TITLE
Fixing parso version to avoid broken autocomplete in ipython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ nestpy==1.4.1     # WFsim dependency
 numba==0.51.2
 numpy==1.18.5     # hold at 1.18.5 due to tensorflow not being upgradable
 pandoc==1.0.2
+parso==0.7.1     # upgrading to 0.8.0 breaks autocomplete in ipython
 pdmongo==0.1.0     # Strax dependency
 pika==1.1.0       # Pegasus
 psutil==5.8.0     # Strax dependency


### PR DESCRIPTION
ipython autocomplete doesn't work with parso 0.8.0, so fixing the version to 0.7.1. 
