### PR TITLE
Remove gfal2 section from setup script

### DIFF
--- a/create-env
+++ b/create-env
@@ -204,10 +204,6 @@ source ${target_dir}/anaconda/bin/activate ${env_name}
 # prepend to LD_LIBRARY_PATH - non-Python tools might be using it
 export LD_LIBRARY_PATH=\$CONDA_PREFIX/lib64:\$CONDA_PREFIX/lib\${LD_LIBRARY_PATH:+:}\${LD_LIBRARY_PATH}
 
-# gfal2
-export GFAL_CONFIG_DIR=\$CONDA_PREFIX/etc/gfal2.d
-export GFAL_PLUGIN_DIR=\$CONDA_PREFIX/lib64/gfal2-plugins/
-
 # rucio
 export RUCIO_HOME=\$CONDA_PREFIX
 export RUCIO_ACCOUNT=xenon-analysis


### PR DESCRIPTION
After updating we hit an issue in gfal where it was looking for specified GFAL_PLUGIN_DIR and GFAL_CONFIG_DIR. This PR removes those lines from the setup script.