### PR TITLE
Add monitor for memory usage in jupyter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ holoviews==1.14.1
 hypothesis==6.0.0
 iminuit==2.2.1
 jupyter==1.0.0
+jupyter-resource-usage   # Memory viewer for notebooks
 jupyterlab==2.2.9
 line_profiler==3.1.0
 lz4==3.1.1        # Strax dependency


### PR DESCRIPTION
Perhaps we can add https://github.com/jupyter-server/jupyter-resource-usage to allow one to see how much memory is being used in the jupyter notebook one is using.