### PR TITLE
unset GFAL_CONFIG_DIR

### DIFF
--- a/create-env
+++ b/create-env
@@ -180,7 +180,7 @@ export OSG_LOCATION=""
 export GLOBUS_LOCATION=""
 export PYTHONPATH=""
 export PERL5LIB=""
-export GFAL_CONFIG_DIR=""
+unset GFAL_CONFIG_DIR
 
 # when inside a container, reset some variables from outside
 


### PR DESCRIPTION
I was hitting the same GFAL_CONFIG_DIR error when this variable is set as an empty string. @rynge I see you have a comment to not use `unset`. Can we try this though?