### PR TITLE
Update TF & numpy simultaniously

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ multihist==0.6.4
 nbsphinx==0.8.1
 nestpy==1.4.1     # WFsim dependency
 numba==0.52.0     # Strax dependency
-numpy==1.18.5     # hold at 1.18.5 due to tensorflow not being upgradable
+numpy==1.19.5
 pandoc==1.0.2
 parso==0.7.1     # upgrading to 0.8.0 breaks autocomplete in ipython
 pdmongo==0.1.0     # Strax dependency
@@ -48,7 +48,7 @@ straxen==0.14.4
 snakeviz==2.1.0
 sphinx==3.4.3
 tables==3.6.1     # pytables, necessary for pandas hdf5 i/o
-tensorflow==2.3.1 # do not upgrade to 2.4.0 - it brings in additional AVX2 requirements (https://github.com/XENONnT/base_environment/issues/433)
+tensorflow==2.4.1 # TF2.4.1 should not bring in additional AVX2 requirements (https://github.com/XENONnT/base_environment/issues/433)
 tensorflow_probability==0.12.1
 tqdm==4.55.1
 utilix==0.4.0       # dependency for straxen, admix


### PR DESCRIPTION
In #433, it was mentioned that TF 2.4.1. should not bring in the additional AVX2 requirements