### PR TITLE
Pin jedi for jupyter 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ GitPython==3.1.12   # Pegasus dependency
 holoviews==1.14.1
 hypothesis==6.0.3
 iminuit==2.3.0
+jedi==0.17.2    # upgrading to 0.18.0 breaks autocomplete in ipython
 jupyter==1.0.0
 jupyter-resource-usage   # Memory viewer for notebooks
 jupyterlab==2.2.9


### PR DESCRIPTION
Like #447, jedi needs to be at a specified version. In fact, by specifying `jedi==0.17.2` one gets also `parso-0.7.1`