### PR TITLE
Add and test wfsim via pipy

### DIFF
--- a/create-env
+++ b/create-env
@@ -98,7 +98,6 @@ ln -s ${target_dir}/anaconda/envs/${env_name}/lib/libboost_python38.a ${target_d
 
 jupyter labextension install @pyviz/jupyterlab_pyviz   # for waveform display in jupyterlab
 announce "Installing non-grid XENON software"
-pip install git+https://github.com/XENONnT/WFSim.git
 pip install git+https://github.com/XENONnT/admix.git
 
 # gfal2-python bindings
@@ -285,5 +284,12 @@ git clone --single-branch --branch v$straxen_version https://github.com/XENONnT/
 pytest straxen || { echo 'straxen tests failed' ; exit 1; }
 rm -r straxen
 
-announce "All done!"
+# wfsim
+announce " ... wfsim tests"
+wfsim_version=`python -c "import wfsim; print(wfsim.__version__)"`
+git clone --single-branch --branch v$wfsim_version https://github.com/XENONnT/wfsim ./wfsim
+pytest wfsim || { echo 'wfsim tests failed' ; exit 1; }
+rm -r wfsim
 
+# Done testing
+announce "All done!"

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,5 +54,5 @@ tensorflow==2.4.1 # TF2.4.1 should not bring in additional AVX2 requirements (ht
 tensorflow_probability==0.12.1
 tqdm==4.56.2
 utilix==0.4.1       # dependency for straxen, admix
+wfsim==0.2.4
 zstd==1.4.8.1     # Strax dependency
-


### PR DESCRIPTION
After https://github.com/XENONnT/WFSim/pull/97, we should be able to more easily install wfsim since it's now on pipy. We could also test it here as it's one of the core packages of the Xenon experiment.
