### PR TITLE
Update straxen

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ scikit-learn==0.24.1
 scipy==1.6.1
 seaborn==0.11.1
 strax==0.13.9
-straxen==0.15.7
+straxen==0.15.8
 snakeviz==2.1.0
 sphinx==3.5.1
 tables==3.6.1     # pytables, necessary for pandas hdf5 i/o


### PR DESCRIPTION
Most importantly, https://github.com/XENONnT/straxen/pull/388 should be added because all these issues with `commentjson` needed to be mitigated.