### PR TITLE
comment on dask upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ codenamize==1.2.3  # for human-readable hashing
 commentjson==0.9.0 # Straxen dependency
 coveralls==3.0.1
 cython==0.29.22
-dask==2021.3.0
+dask==2021.3.0    # straxen dependency, upgrade to 2021.3.1 breaks straxen at py3.6
 dask-jobqueue==0.7.2
 datashader==0.12.1
 dill==0.3.3      # Strax dependency


### PR DESCRIPTION
Dask 2021.3.1 is causing some issues for py3.6 in straxen. Perhaps this will be solved in the future, perhaps not and we should stop supporting/testing py3.6 in straxen.

Either way, it's good to comment, since it might cause annoying issues and dask is by far not a core dependency of strax(en),