### PR TITLE
Bump straxen for rundb

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ scikit-learn==0.24.1
 scipy==1.6.2
 seaborn==0.11.1
 strax==0.15.0
-straxen==0.18.0
+straxen==0.18.1
 snakeviz==2.1.0
 sphinx==3.5.3
 tables==3.6.1     # pytables, necessary for pandas hdf5 i/o


### PR DESCRIPTION
Use https://github.com/XENONnT/straxen/releases/tag/v0.18.1 as we have better support for finding reprocessed data.