### PR TITLE
Do dependabot monthly

### DIFF
--- a/.dependabot/.config.yml
+++ b/.dependabot/.config.yml
@@ -3,7 +3,7 @@ version: 2
 update_configs:
   - package_manager: "python"
     directory: "/"
-    update_schedule: "weekly"
+    update_schedule: "monthly"
     ignored_updates:
       - match:
           # ignore dask updates since it is not supported by python 3.6


### PR DESCRIPTION
I'm falling behind on the weekly dependabot updates (and growing more and more annoyed with them). I think updating the dependencies once a month should be fine, and we'll probably be more prompt about merging them if it's not every single week. For the XENON-specific software we can update manually. 

How does this sound @jorana @ramirezdiego @rynge? 
