### PR TITLE
Version bump for strax and straxen.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,8 +46,8 @@ torch==1.8.1     # Strax dependency
 scikit-learn==0.24.1
 scipy==1.6.2
 seaborn==0.11.1
-strax==0.15.0
-straxen==0.18.1
+strax==0.15.1
+straxen==0.18.2
 snakeviz==2.1.0
 sphinx==3.5.4
 tables==3.6.1     # pytables, necessary for pandas hdf5 i/o


### PR DESCRIPTION
New versions for strax and straxen. Please note that we changed some URLs for the SCADAInterface. This means we have to updated the .xenon_config once the new versions are deployed. 