### PR TITLE
WFSim bump

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -56,6 +56,6 @@ tensorflow==2.5.0 # TF2.4.1 should not bring in additional AVX2 requirements (ht
 tensorflow_probability==0.12.2
 tqdm==4.61.0
 utilix==0.6.0      # dependency for straxen, admix
-wfsim==0.5.4
+wfsim==0.5.5
 xe-admix==0.3.1
 zstd==1.4.9.1     # Strax dependency


### PR DESCRIPTION
@ershockley The WFSim installation was disabled from the MC container, since it is also present in the "base" one. So let's bump it here and then deploy both, base and MC.