### PR TITLE
Use local cutax installation

### DIFF
--- a/create-env
+++ b/create-env
@@ -7,8 +7,7 @@
 gfal2_bindings_version=ac5cd70bc0654cd5b72cc01085eeaafb469b9622 # project is not releasing often enough
 gfal2_util_version=1.6.0
 rucio_version=1.23.14
-# admix_version=0.2.3 # commented out to use master
-
+cutax_version=0.1.0
 #######################################################################
 
 set -e
@@ -229,6 +228,21 @@ done
 config_path=/project2/lgrandi/xenonnt/xenon.config
 if [ -e \$config_path ]; then
    export XENON_CONFIG=\$config_path
+fi
+
+# grab a local cutax installation if we have one
+MIDWAY_CUTAX_DIR=/dali/lgrandi/xenonnt/software/cutax/v${cutax_version}
+OSG_CUTAX_DIR=/xenon/software/cutax/v${cutax_version}
+if [ "x\$CUTAX_LOCATION" = "x" ]; then
+  for dir in $MIDWAY_CUTAX_DIR $OSG_CUTAX_DIR; do
+    if [ -e \$dir ]; then
+       export CUTAX_LOCATION=\$dir
+    fi
+  done
+fi
+
+if [ -n "\CUTAX_LOCATION" ]; then
+  pip install -e $CUTAX_LOCATION --no-deps --quiet --no-input
 fi
 
 EOF

--- a/create-env
+++ b/create-env
@@ -234,7 +234,7 @@ fi
 MIDWAY_CUTAX_DIR=/dali/lgrandi/xenonnt/software/cutax/v${cutax_version}
 OSG_CUTAX_DIR=/xenon/software/cutax/v${cutax_version}
 if [ "x\${CUTAX_LOCATION}" = "x" ]; then
-  for dir in \{MIDWAY_CUTAX_DIR} \${OSG_CUTAX_DIR}; do
+  for dir in \${MIDWAY_CUTAX_DIR} \${OSG_CUTAX_DIR}; do
     if [ -e \$dir ]; then
        export CUTAX_LOCATION=\$dir
     fi

--- a/create-env
+++ b/create-env
@@ -242,7 +242,7 @@ if [ "x\${CUTAX_LOCATION}" = "x" ]; then
 fi
 
 if [ -n "\${CUTAX_LOCATION}" ]; then
-  pip install -e ${CUTAX_LOCATION} --no-deps --quiet --no-input
+  pip install -e \${CUTAX_LOCATION} --no-deps --quiet --no-input
 fi
 
 EOF

--- a/create-env
+++ b/create-env
@@ -236,12 +236,13 @@ OSG_CUTAX_DIR=/xenon/software/cutax/v${cutax_version}
 if [ "x\${CUTAX_LOCATION}" = "x" ]; then
   for dir in \${MIDWAY_CUTAX_DIR} \${OSG_CUTAX_DIR}; do
     if [ -e \$dir ]; then
-       export CUTAX_LOCATION=\$dir
+       CUTAX_LOCATION=\$dir
     fi
   done
 fi
 
 if [ -n "\${CUTAX_LOCATION}" ]; then
+  export CUTAX_LOCATION
   pip install -e \${CUTAX_LOCATION} --no-deps --quiet --no-input
 fi
 

--- a/create-env
+++ b/create-env
@@ -7,7 +7,7 @@
 gfal2_bindings_version=ac5cd70bc0654cd5b72cc01085eeaafb469b9622 # project is not releasing often enough
 gfal2_util_version=1.6.0
 rucio_version=1.23.14
-cutax_version=0.1.0
+cutax_version=0.1.1
 #######################################################################
 
 set -e

--- a/create-env
+++ b/create-env
@@ -234,7 +234,7 @@ fi
 MIDWAY_CUTAX_DIR=/dali/lgrandi/xenonnt/software/cutax/v${cutax_version}
 OSG_CUTAX_DIR=/xenon/software/cutax/v${cutax_version}
 if [ "x\${CUTAX_LOCATION}" = "x" ]; then
-  for dir in ${MIDWAY_CUTAX_DIR} ${OSG_CUTAX_DIR}; do
+  for dir in \{MIDWAY_CUTAX_DIR} \${OSG_CUTAX_DIR}; do
     if [ -e \$dir ]; then
        export CUTAX_LOCATION=\$dir
     fi

--- a/create-env
+++ b/create-env
@@ -233,16 +233,16 @@ fi
 # grab a local cutax installation if we have one
 MIDWAY_CUTAX_DIR=/dali/lgrandi/xenonnt/software/cutax/v${cutax_version}
 OSG_CUTAX_DIR=/xenon/software/cutax/v${cutax_version}
-if [ "x\$CUTAX_LOCATION" = "x" ]; then
-  for dir in $MIDWAY_CUTAX_DIR $OSG_CUTAX_DIR; do
+if [ "x\${CUTAX_LOCATION}" = "x" ]; then
+  for dir in ${MIDWAY_CUTAX_DIR} ${OSG_CUTAX_DIR}; do
     if [ -e \$dir ]; then
        export CUTAX_LOCATION=\$dir
     fi
   done
 fi
 
-if [ -n "\CUTAX_LOCATION" ]; then
-  pip install -e $CUTAX_LOCATION --no-deps --quiet --no-input
+if [ -n "\${CUTAX_LOCATION}" ]; then
+  pip install -e ${CUTAX_LOCATION} --no-deps --quiet --no-input
 fi
 
 EOF


### PR DESCRIPTION
This PR looks for a local cutax installation on specific hosts (Midway + OSG login node) and installs with pip -e.

One tricky thing is that this might overwrite a user's own local installation, which is not ideal. I see two possible solutions: 

1. (implemented now) the user would pass CUTAX_LOCATION={path} when entering the container to override the default one in setup.sh
2. (I just thought of) we check during setup if cutax is already in the environment using `pip list | grep cutax`.

Not sure which is better. Option 1 is better for ensuring analysts aren't accidentally using a different cutax, while option 2 makes it a touch easier to develop cutax in the container since you wouldn't need to remember to pass this env variable. 

 