### PR TITLE
Remove pip deprecation warning

### DIFF
--- a/create-env
+++ b/create-env
@@ -243,7 +243,7 @@ fi
 
 if [ -n "\${CUTAX_LOCATION}" ]; then
   export CUTAX_LOCATION
-  pip install \${CUTAX_LOCATION} --no-deps --quiet --no-input --user
+  pip install \${CUTAX_LOCATION} --no-deps --quiet --no-input --user --use-feature=in-tree-build
 fi
 
 EOF


### PR DESCRIPTION
I'm following the directions that pip keeps telling us about an upcoming change. I have a small concern of permissions issues, but I guess we will see. Depends if anything actually gets built or not. 

```
DEPRECATION: A future pip version will change local packages to be built in-place without first copying to a temporary directory. We recommend you use --use-feature=in-tree-build to test your packages with this new behavior before it becomes the default.
```