### PR TITLE
Use latest version of cutax + remove deprecation warning (for real)

### DIFF
--- a/create-env
+++ b/create-env
@@ -7,7 +7,7 @@
 gfal2_bindings_version=ac5cd70bc0654cd5b72cc01085eeaafb469b9622 # project is not releasing often enough
 gfal2_util_version=1.6.0
 rucio_version=1.23.14
-cutax_version=0.2.0
+cutax_version=latest
 #######################################################################
 
 set -e
@@ -231,8 +231,8 @@ if [ -e \$config_path ]; then
 fi
 
 # grab a local cutax installation if we have one
-MIDWAY_CUTAX_DIR=/dali/lgrandi/xenonnt/software/cutax/v${cutax_version}
-OSG_CUTAX_DIR=/xenon/software/cutax/v${cutax_version}
+MIDWAY_CUTAX_DIR=/dali/lgrandi/xenonnt/software/cutax/${cutax_version}
+OSG_CUTAX_DIR=/xenon/software/cutax/${cutax_version}
 if [ "x\${CUTAX_LOCATION}" = "x" ]; then
   for dir in \${MIDWAY_CUTAX_DIR} \${OSG_CUTAX_DIR}; do
     if [ -e \$dir ]; then
@@ -241,9 +241,9 @@ if [ "x\${CUTAX_LOCATION}" = "x" ]; then
   done
 fi
 
-if [ -n "\${CUTAX_LOCATION}" ]; then
+if [ -e "\${CUTAX_LOCATION}" ]; then
   export CUTAX_LOCATION
-  pip install \${CUTAX_LOCATION} --no-deps --quiet --no-input --user 
+  pip install \${CUTAX_LOCATION} -qq --no-deps --no-input --user
 fi
 
 EOF


### PR DESCRIPTION
This PR changes the base env to point to the `latest` version of cutax on Midway, rather than a tagged version. This has the downside of things potentially changing underneath analysts but upside for distributing the software faster. 

I think it's okay to merge this, but only if we are better about regular tagged images (which absolutely should use tagged cutax versions).