### PR TITLE
Dont update context if using latest cutax

### DIFF
--- a/.github/scripts/update_context_wrapper.sh
+++ b/.github/scripts/update_context_wrapper.sh
@@ -4,9 +4,10 @@
 cd $HOME
 # get cutax version
 CUTAX_VERSION=$(grep "cutax_version=" create-env)
-CUTAX_VERSION=v${CUTAX_VERSION//cutax_version=}
+CUTAX_VERSION=${CUTAX_VERSION//cutax_version=}
+if [ $CUTAX_VERSION = 'latest' ]; then echo "Dont upload for latest version" && exit 0; fi
 cd cutax
-git checkout $CUTAX_VERSION
-python setup.py develop --user
+git checkout v$CUTAX_VERSION
+python setup.py install --user
 cd $HOME
 python .github/scripts/update-context-collection.py


### PR DESCRIPTION
Since the development container now points to master branch of cutax, let's not update context collection in that case. 