### PR TITLE
Use PYTHONPATH instead of pip for cutax

### DIFF
--- a/create-env
+++ b/create-env
@@ -241,9 +241,16 @@ if [ "x\${CUTAX_LOCATION}" = "x" ]; then
   done
 fi
 
-if [ -e "\${CUTAX_LOCATION}" ]; then
-  export CUTAX_LOCATION
-  pip install \${CUTAX_LOCATION} -qq --no-deps --no-input --user
+if [ "x\$INSTALL_CUTAX" = "x" ]; then
+    export INSTALL_CUTAX=1
+fi
+
+if [ \$INSTALL_CUTAX -eq 1 ]; then
+  if [ -e "\${CUTAX_LOCATION}" ]; then
+    export CUTAX_LOCATION
+    export PYTHONPATH=\${CUTAX_LOCATION}:\$PYTHONPATH
+  else echo -e "Warning: you passed\nCUTAX_LOCATION=\${CUTAX_LOCATION}\nbut that path does not exist. Your cutax installation may not work."
+  fi
 fi
 
 EOF


### PR DESCRIPTION
This PR aims to resolve a problem reported by @kdund that originates due to race conditions of many jobs trying to install cutax locally at the same time. 

Now the cutax directory is just appended to the PYTHONPATH, which does not involve any installation and so removes this race condition. It's also more transparent because 

```
import cutax
print(cutax.__file__)
```
returns the path on `dali`, not the user's home directory. 

In cases where the user is developing cutax, there are two options to use the user's local cutax: 

1) Set the env variable `CUTAX_LOCATION=/path/to/your/own/cutax` 
2) Don't install cutax at all (this assumes you did `python setup.py develop` or something similar) by setting env variable `INSTALL_CUTAX=0` 

For example, I could do the following: 

```
CUTAX_LOCATION=/evans/personal/cutax singularity shell /path/to/container
```

or 

```
INSTALL_CUTAX=0 singularity shell /path/to/container
```
