### PR TITLE
Set PYTHONCACHEPREFIX to /tmp

### DIFF
--- a/create-env
+++ b/create-env
@@ -216,7 +216,7 @@ fi
 
 
 # change where we cache the .pyc files
-export PYTHONPYCACHEPREFIX=/tmp
+export PYTHONPYCACHEPREFIX=/tmp/\$USER
 
 # site-specific stuff
 for space in /project2/lgrandi/grid_proxy /xenon/grid_proxy; do

--- a/create-env
+++ b/create-env
@@ -215,6 +215,9 @@ if [ "x\$X509_CERT_DIR" = "x" ]; then
 fi
 
 
+# change where we cache the .pyc files
+export PYTHONPYCACHEPREFIX=/tmp
+
 # site-specific stuff
 for space in /project2/lgrandi/grid_proxy /xenon/grid_proxy; do
     if [ -d \$space ]; then

--- a/create-env
+++ b/create-env
@@ -215,15 +215,14 @@ if [ "x\$X509_CERT_DIR" = "x" ]; then
 fi
 
 
-# change where we cache the .pyc files
-export PYTHONPYCACHEPREFIX=/tmp/\$USER
-
 # site-specific stuff
 for space in /project2/lgrandi/grid_proxy /xenon/grid_proxy; do
     if [ -d \$space ]; then
         if [ "x\$X509_USER_PROXY" = "x" ]; then
             export X509_USER_PROXY=\${space}/xenon_service_proxy
         fi
+        # change where we cache the .pyc files if we are on one of these sites.
+        export PYTHONPYCACHEPREFIX=/tmp/\$USER
     fi
 done
 


### PR DESCRIPTION
After #752, we now get a problem where inidividual user's `__pycache__` can be written to the source code directory (if they have write access). This changes where those files are written.