### PR TITLE
Split build into docker layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,10 +54,14 @@ RUN source /opt/rh/devtoolset-9/enable && \
     rm -f create-env conda_xnt.yml
 
 ADD requirements.txt /tmp/
-RUN cd /tmp && pip install -r requirements.txt
+RUN cd /tmp && conda activate &&  \
+    pip install -r requirements.txt && \
+    rm -f requirements.txt
 
 ADD xenon-requirements.txt /tmp/
-RUN cd /tmp && pip install -r xenon-requirements.txt
+RUN cd /tmp && conda activate && \
+    pip install -r xenon-requirements.txt &&\
+    rm -f xenon-requirements.txt
 
 # relax permissions so we can build cvmfs tar balls
 RUN chmod 1777 /cvmfs

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,12 +46,18 @@ RUN  yum -y install centos-release-scl && \
     yum clean all && \
     localedef -i en_US -f UTF-8 en_US.UTF-8
 
-ADD create-env conda_xnt.yml requirements.txt /tmp/
+ADD create-env conda_xnt.yml /tmp/
 
 RUN source /opt/rh/devtoolset-9/enable && \
     cd /tmp && \
     bash create-env /opt/XENONnT ${XENONnT_TAG} && \
     rm -f create-env conda_xnt.yml
+
+ADD requirements.txt /tmp/
+RUN cd /tmp && pip install -r requirements.txt
+
+ADD xenon-requirements.txt /tmp/
+RUN cd /tmp && pip install -r xenon-requirements.txt
 
 # relax permissions so we can build cvmfs tar balls
 RUN chmod 1777 /cvmfs

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,12 +54,14 @@ RUN source /opt/rh/devtoolset-9/enable && \
     rm -f create-env conda_xnt.yml
 
 ADD install-requirements requirements.txt /tmp/
-RUN cd /tmp && \
+RUN source /opt/rh/devtoolset-9/enable && \
+    cd /tmp && \
     bash install-requirements /opt/XENONnT ${XENONnT_TAG} && \
     rm -f install-requirements requirements.txt
 
 ADD install-xenon-requirements xenon-requirements.txt /tmp/
-RUN cd /tmp && \
+RUN source /opt/rh/devtoolset-9/enable && \
+    cd /tmp && \
     bash install-xenon-requirements /opt/XENONnT ${XENONnT_TAG} && \
     rm -f install-xenon-requirements xenon-requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,15 +53,15 @@ RUN source /opt/rh/devtoolset-9/enable && \
     bash create-env /opt/XENONnT ${XENONnT_TAG} && \
     rm -f create-env conda_xnt.yml
 
-ADD requirements.txt /tmp/
-RUN cd /tmp && conda activate &&  \
-    pip install -r requirements.txt && \
-    rm -f requirements.txt
+ADD install-requirements requirements.txt /tmp/
+RUN cd /tmp && \
+    bash install-requirements /opt/XENONnT ${XENONnT_TAG} && \
+    rm -f install-requirements requirements.txt
 
-ADD xenon-requirements.txt /tmp/
-RUN cd /tmp && conda activate && \
-    pip install -r xenon-requirements.txt &&\
-    rm -f xenon-requirements.txt
+ADD install-xenon-requirements xenon-requirements.txt /tmp/
+RUN cd /tmp && \
+    bash install-xenon-requirements /opt/XENONnT ${XENONnT_TAG} && \
+    rm -f install-xenon-requirements xenon-requirements.txt
 
 # relax permissions so we can build cvmfs tar balls
 RUN chmod 1777 /cvmfs

--- a/conda_xnt.yml
+++ b/conda_xnt.yml
@@ -4,5 +4,3 @@ dependencies:
   - nb_conda
   - pip
   - python=3.8
-  - pip:
-    - -r requirements.txt

--- a/conda_xnt.yml
+++ b/conda_xnt.yml
@@ -4,3 +4,5 @@ dependencies:
   - nb_conda
   - pip
   - python=3.8
+  - jupyter=1.0.0
+  - lupyterlab=3.2.1

--- a/conda_xnt.yml
+++ b/conda_xnt.yml
@@ -5,4 +5,4 @@ dependencies:
   - pip
   - python=3.8
   - jupyter=1.0.0
-  - lupyterlab=3.2.1
+  - jupyterlab=3.2.1

--- a/install-requirements
+++ b/install-requirements
@@ -26,7 +26,10 @@ if [ "X$target_dir" = "X" ]; then
     exit 1
 fi
 
-announce "Activating Anaconda environment"
+echo "Activating Anaconda environment"
 source $target_dir/anaconda/bin/activate ${env_name}
 
+echo "Installing third party packages..."
 pip install -r requirements.txt
+
+echo "Done."

--- a/install-requirements
+++ b/install-requirements
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+#######################################################################
+#
+# versions in this release
+
+gfal2_bindings_version=ac5cd70bc0654cd5b72cc01085eeaafb469b9622 # project is not releasing often enough
+gfal2_util_version=1.6.0
+rucio_version=1.23.14
+cutax_version=latest
+#######################################################################
+
+set -e
+
+target_dir=$1
+
+xenonnt_tag=$2
+if [ "x$xenonnt_tag" = "x" ]; then
+    xenonnt_tag=development
+fi
+
+env_name=XENONnT_${xenonnt_tag}
+
+if [ "X$target_dir" = "X" ]; then
+    echo "Please specify a target directory. Example: ./create-env /tmp/myenv" >&1
+    exit 1
+fi
+
+if [ -e $target_dir ]; then
+    echo "Target directory already exists - refusing to work on it" >&1
+    exit 1
+fi
+
+announce "Activating Anaconda environment"
+source $target_dir/anaconda/bin/activate ${env_name}
+
+pip install -r requirements.txt

--- a/install-requirements
+++ b/install-requirements
@@ -26,11 +26,6 @@ if [ "X$target_dir" = "X" ]; then
     exit 1
 fi
 
-if [ -e $target_dir ]; then
-    echo "Target directory already exists - refusing to work on it" >&1
-    exit 1
-fi
-
 announce "Activating Anaconda environment"
 source $target_dir/anaconda/bin/activate ${env_name}
 

--- a/install-xenon-requirements
+++ b/install-xenon-requirements
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+#######################################################################
+#
+# versions in this release
+
+gfal2_bindings_version=ac5cd70bc0654cd5b72cc01085eeaafb469b9622 # project is not releasing often enough
+gfal2_util_version=1.6.0
+rucio_version=1.23.14
+cutax_version=latest
+#######################################################################
+
+set -e
+
+target_dir=$1
+
+xenonnt_tag=$2
+if [ "x$xenonnt_tag" = "x" ]; then
+    xenonnt_tag=development
+fi
+
+env_name=XENONnT_${xenonnt_tag}
+
+if [ "X$target_dir" = "X" ]; then
+    echo "Please specify a target directory. Example: ./create-env /tmp/myenv" >&1
+    exit 1
+fi
+
+if [ -e $target_dir ]; then
+    echo "Target directory already exists - refusing to work on it" >&1
+    exit 1
+fi
+
+pip install -r xenon-requirements.txt

--- a/install-xenon-requirements
+++ b/install-xenon-requirements
@@ -26,5 +26,10 @@ if [ "X$target_dir" = "X" ]; then
     exit 1
 fi
 
+echo "Activating Anaconda environment"
+source $target_dir/anaconda/bin/activate ${env_name}
 
+echo "Installing xenon packages..."
 pip install -r xenon-requirements.txt
+
+echo "Done."

--- a/install-xenon-requirements
+++ b/install-xenon-requirements
@@ -26,9 +26,5 @@ if [ "X$target_dir" = "X" ]; then
     exit 1
 fi
 
-if [ -e $target_dir ]; then
-    echo "Target directory already exists - refusing to work on it" >&1
-    exit 1
-fi
 
 pip install -r xenon-requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,8 +51,6 @@ pytest-runner==5.3.1
 scikit-learn==1.0.1
 scipy==1.7.1
 seaborn==0.11.2
-strax==1.1.2
-straxen==1.1.3
 snakeviz==2.1.1
 sphinx==4.2.0
 tables==3.6.1     # pytables, necessary for pandas hdf5 i/o
@@ -61,8 +59,5 @@ tensorflow_probability==0.14.1
 torch==1.10.0     # Strax dependency
 typing_extensions==3.7.4.3  # Tensorflow and bokeh dependency
 tqdm==4.62.3
-utilix==0.6.5      # dependency for straxen, admix
-wfsim==0.5.10
-git+git://github.com/ershockley/admix@v1.0.6
 xarray==0.19.0
 zstd==1.4.9.1     # Strax dependency

--- a/xenon-requirements.txt
+++ b/xenon-requirements.txt
@@ -1,5 +1,5 @@
 strax==1.1.2
 straxen==1.1.3
 utilix==0.6.5      # dependency for straxen, admix
-wfsim==0.5.10
+wfsim==0.5.11
 git+git://github.com/ershockley/admix@v1.0.6

--- a/xenon-requirements.txt
+++ b/xenon-requirements.txt
@@ -1,0 +1,5 @@
+strax==1.1.2
+straxen==1.1.3
+utilix==0.6.5      # dependency for straxen, admix
+wfsim==0.5.10
+git+git://github.com/ershockley/admix@v1.0.6


### PR DESCRIPTION
Currently almost the entire build is being done in one docker RUN statement. This combines into a single docker layer parts of our environment like conda and boost installs which are rarely updated and slow to install with the parts that are quick to install and are updated almost every new build like xenons python packages. This results in long build times when simply updating a single python package like strax/wfsim.

This PR splits the create-env into thress layers:

1. The "heavy " stuff like conda, boost etc. - kept inside the create-env script.  Not expected to change very often.
2. Third party python dependencies - get their own layer since they are expected to change with moderate frequency.
3. Xenon python packages - This is built last since its the most frequently updated.

This should help speed up the build time when releasing new xenon packages since the previous layers will not need to be rebuilt.

Before we merge we should test that the build succeeds with these changes.