### PR TITLE
Add statsmodels

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -51,6 +51,7 @@ pytest-runner==5.3.1
 scikit-learn==1.0.1
 scipy==1.7.1
 seaborn==0.11.2
+statsmodels==0.13.0
 strax==1.1.2
 straxen==1.1.3
 snakeviz==2.1.1


### PR DESCRIPTION
Add statsmodels package because it provides classes and functions for the estimation of many different statistical models, such as `statsmodels.stats.proportion.proportion_confint` to estimate the Binomial proportion confidence interval. 