### PR TITLE
Update tests to run pema

### DIFF
--- a/.github/scripts/do_tests.sh
+++ b/.github/scripts/do_tests.sh
@@ -38,3 +38,11 @@ echo "Testing $wfsim_version"
 git clone --single-branch --branch v$wfsim_version https://github.com/XENONnT/wfsim ./wfsim
 pytest wfsim || { echo 'wfsim tests failed' ; exit 1; }
 rm -r wfsim
+
+# Pema
+echo " ... pema tests"
+pema_version=`python -c "import pema; print(pema.__version__)"`
+echo "Testing $pema_version"
+git clone --single-branch --branch v$pema_version https://github.com/XENONnT/pema ./pema
+pytest pema || { echo 'pema tests failed' ; exit 1; }
+rm -r pema


### PR DESCRIPTION
`pema` has the [highest coverage (95%)](https://coveralls.io/github/XENONnT/pema?branch=master) in our software stack. It certainly doesn't hurt to include it in the testing here.

It takes about 8-12 minutes depending on the host.