### PR TITLE
Add quick test

### DIFF
--- a/.github/workflows/quick_dep_test.yml
+++ b/.github/workflows/quick_dep_test.yml
@@ -1,0 +1,36 @@
+name: Quick requirements test
+
+# Trigger this code when a new release is published
+on:
+  workflow_dispatch:
+  release:
+    types: [ created ]
+  pull_request:
+  push:
+    branches:
+      - master
+      - stable
+
+jobs:
+  update:
+    name: "quick test py${{ matrix.python-version }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: False
+      matrix:
+        python-version: [3.8]
+    steps:
+      # Setup and installation
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Setup python
+        uses: actions/setup-python@v2.3.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: 'requirements.txt'
+      - name: Install requirements
+        run:
+          pip install -r requirements.txt
+      - name: goodbye
+        run: echo "tests done, bye bye"

--- a/.github/workflows/quick_dep_test.yml
+++ b/.github/workflows/quick_dep_test.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   update:
-    name: "quick test py${{ matrix.python-version }}"
+    name: "py${{ matrix.python-version }}"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: False


### PR DESCRIPTION
The container takes about one hour to build, so iterating changes is sometimes slow. In this PR I propose to add a quick test, that only tries to install the dependencies as this is where things go wrong most often, allowing for faster iterations when updateding base-environment.