### PR TITLE
Add release tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensciencegrid/osgvo-el7
+FROM opensciencegrid/osgvo-el7:release
 
 LABEL opensciencegrid.name="XENONnT"
 LABEL opensciencegrid.description="Base software environment for XENONnT, including Python 3.8 and data management tools"


### PR DESCRIPTION
There seams to be an issue with the osgvo-el7:latest  image which is causing builds to fail. This pins the base container to the :release tag.