### PR TITLE
use host network for cvmfs tarballing

### DIFF
--- a/deployhq/build-cvmfs-tar.sh
+++ b/deployhq/build-cvmfs-tar.sh
@@ -22,7 +22,7 @@ cd ~/deployhq/
 mkdir -p generated
 chmod 1777 generated
 cp ~/deployhq/deployhq/build-cvmfs-tar-inside-helper.sh .
-docker run -v `pwd`:/srv -i -t --rm \
+docker run -v `pwd`:/srv -i -t --rm --network=host \
        xenonnt/base-environment:$TAG \
        /bin/bash -c "/srv/build-cvmfs-tar-inside-helper.sh $TAG"
 


### PR DESCRIPTION
docker is also used for tarballing cvmfs env so need to also use host networt for that stage as well