### PR TITLE
Bump Numba

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ multihist==0.6.5
 nbsphinx==0.8.9
 nestpy==2.0.0                                      # WFsim dependency
 npshmex==0.2.1                                     # Strax dependency
-numba==0.55.2                                      # Strax dependency
+numba==0.56.3                                      # Strax dependency
 numpy==1.22.4
 packaging==21.3
 pandas==1.4.4


### PR DESCRIPTION
It seems https://github.com/XENONnT/epix/issues/58 only affects 0.56.0