### PR TITLE
Bump numba

### DIFF
--- a/.github/scripts/do_tests.sh
+++ b/.github/scripts/do_tests.sh
@@ -35,6 +35,9 @@ case "$1" in
      rm straxen/tests/storage/test_rucio_remote.py;
     fi
     # /TODO
+    # Make sure all new numba code is cached to one directory
+    mkdir $HOME/numba_cache
+    export NUMBA_CACHE_DIR=$HOME/numba_cache/
     bash straxen/.github/scripts/create_pre_apply_function.sh $HOME
     pytest -v straxen/tests || { echo 'straxen tests failed' ; exit 1; }
     rm -r straxen

--- a/.github/scripts/do_tests.sh
+++ b/.github/scripts/do_tests.sh
@@ -39,7 +39,7 @@ case "$1" in
     mkdir $HOME/numba_cache
     export NUMBA_CACHE_DIR=$HOME/numba_cache/
     bash straxen/.github/scripts/create_pre_apply_function.sh $HOME
-    pytest -v straxen/tests || { echo 'straxen tests failed' ; exit 1; }
+    pytest -vx straxen/tests || { echo 'straxen tests failed' ; exit 1; }
     rm -r straxen
     rm $HOME/pre_apply_function.py
   ;;

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,6 @@ jupyter==1.0.0
 jupyter-resource-usage==0.6.2                      # Memory viewer for notebooks
 jupyterlab==3.4.5
 keras==2.10.0
-llvmlite==0.39.1
 line_profiler==3.5.1
 lz4==4.0.2                                         # Strax dependency
 matplotlib==3.5.3                                  # update to 3.6.0 breaks straxen examples
@@ -74,5 +73,4 @@ wfsim==1.0.2
 git+https://github.com/ershockley/admix@v1.0.8
 xarray==2022.10.0
 xedocs==0.1.25
-zipp==3.8.1
 zstd==1.5.2.6                                      # Strax dependency

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ multihist==0.6.5
 nbsphinx==0.8.9
 nestpy==2.0.0                                      # WFsim dependency
 npshmex==0.2.1                                     # Strax dependency
-numba==0.56.2                                      # Strax dependency
+numba==0.56.3                                      # Strax dependency
 numpy==1.23.0
 packaging==21.3
 pandas==1.5.0
@@ -75,5 +75,3 @@ git+https://github.com/ershockley/admix@v1.0.8
 xarray==2022.10.0
 xedocs==0.1.25
 zstd==1.5.2.6                                      # Strax dependency
-
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,4 +74,5 @@ wfsim==1.0.2
 git+https://github.com/ershockley/admix@v1.0.8
 xarray==2022.10.0
 xedocs==0.1.25
+zipp==3.8.1
 zstd==1.5.2.6                                      # Strax dependency

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ nbsphinx==0.8.9
 nestpy==2.0.0                                      # WFsim dependency
 npshmex==0.2.1                                     # Strax dependency
 numba==0.56.3                                      # Strax dependency
-numpy==1.23.0
+numpy==1.23.4
 packaging==21.3
 pandas==1.5.0
 pandoc==2.2


### PR DESCRIPTION
Seeing some numba compilation errors. Make sure to use a different cache during testing. 

Should we prevent caching functions in the main env in the first place?