### PR TITLE
Use host network for test build

### DIFF
--- a/.github/workflows/test_and_update.yml
+++ b/.github/workflows/test_and_update.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Build container
         run: |
             while sleep 9m; do echo "=====[ Build is still running after $SECONDS seconds ]====="; done &
-            docker build -t testing . --build-arg XENONnT_TAG=testing
+            docker build -t testing . --build-arg XENONnT_TAG=testing --network host
       - name: Start test MongoDB (doesn't end up in any build or so)
         uses: supercharge/mongodb-github-action@1.6.0
         with:


### PR DESCRIPTION
Network error causing builds to sometimes fail in tests. Try using host network for build.