### PR TITLE
add sklearn env variable

### DIFF
--- a/.github/scripts/do_tests.sh
+++ b/.github/scripts/do_tests.sh
@@ -4,6 +4,7 @@ echo "Running tests"
 
 # spool up test-database for tests
 export TEST_MONGO_URI='mongodb://localhost:27017/'
+export SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True
 
 
 case "$1" in


### PR DESCRIPTION
add 
export SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True
some dependency still uses the old name, causing tests to fail