### PR TITLE
Downgrade numba

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ holoviews==1.15.4
 hypothesis==6.62.1
 iminuit==2.18.0
 ipympl==0.9.2                                      # For online monitoring
+ipykernel==6.22.0                               # For ipywidgets 
 git+https://github.com/XENONnT/inference_interface@v0.0.0
 jedi==0.17.2                                       # upgrading to 0.18.0 breaks autocomplete in ipython
 jupyter==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ holoviews==1.15.4
 hypothesis==6.62.1
 iminuit==2.18.0
 ipympl==0.9.2                                      # For online monitoring
+ipywidgets==8.0.5                                  # For online monitoring
 ipykernel==6.22.0                               # For ipywidgets 
 git+https://github.com/XENONnT/inference_interface@v0.0.0
 jedi==0.17.2                                       # upgrading to 0.18.0 breaks autocomplete in ipython

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ multihist==0.6.5
 nbsphinx==0.8.9
 nestpy==1.5.4                                      # WFSim/epix dependency - do not update unless validated
 npshmex==0.2.1                                     # Strax dependency
-numba==0.56.4                                      # Strax dependency
+numba==0.55.2                                      # Strax dependency
 numpy==1.23.4
 packaging==23.0
 pandas==1.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ nbsphinx==0.8.9
 nestpy==1.5.4                                      # WFSim/epix dependency - do not update unless validated
 npshmex==0.2.1                                     # Strax dependency
 numba==0.55.2                                      # Strax dependency
-numpy==1.23.4
+numpy==1.22.4
 packaging==23.0
 pandas==1.5.2
 pandoc==2.2


### PR DESCRIPTION
0.55.2 is stable for epix, see https://github.com/XENONnT/base_environment/pull/1064 I think we should keep dependabot away from this one for a bit, until we have the time to debug the epix part (doing some development now).

If you have strong opinions on keeping the slightly newer numba version, I'll then uninstall and reinstall numba in the MC container.