### PR TITLE
Bump cutax version

### DIFF
--- a/create-env
+++ b/create-env
@@ -8,7 +8,7 @@ gfal2_bindings_version=ac5cd70bc0654cd5b72cc01085eeaafb469b9622 # project is not
 gfal2_util_version=1.6.0
 rucio_version=1.23.14
 ## REMEMBER THE 'v' IN CUTAX_VERSION!! (unless it is 'latest')
-cutax_version=v1.14.2
+cutax_version=v1.14.3
 #######################################################################
 
 set -e


### PR DESCRIPTION
Just includes these commits: https://github.com/XENONnT/cutax/releases/tag/v1.14.3
No lineage changes.