### PR TITLE
Fix ipython version and add comm dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ blosc==1.11.1                                      # Strax dependency
 bokeh==2.4.3
 boltons==21.0.0
 codenamize==1.2.3                                  # for human-readable hashing
+comm==0.1.3
 commentjson==0.9.0                                 # Straxen dependency
 coveralls==3.3.1
 cython==0.29.32

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ holoviews==1.15.4
 hypothesis==6.62.1
 iminuit==2.18.0
 ipympl==0.9.2                                      # For online monitoring
-ipywidgets==8.0.5                                  # For online monitoring
+ipywidgets==8.0.6                                  # For online monitoring
 ipykernel==6.22.0                               # For ipywidgets 
 ipython==8.12.1
 git+https://github.com/XENONnT/inference_interface@v0.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ holoviews==1.15.4
 hypothesis==6.62.1
 iminuit==2.18.0
 ipympl==0.9.2                                      # For online monitoring
-ipywidgets==8.0.6                                  # For online monitoring
+ipywidgets==8.0.5                                  # For online monitoring
 ipykernel==6.22.0                               # For ipywidgets 
 ipython==8.12.1
 git+https://github.com/XENONnT/inference_interface@v0.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ iminuit==2.18.0
 ipympl==0.9.2                                      # For online monitoring
 ipywidgets==8.0.6                                  # For online monitoring
 ipykernel==6.22.0                               # For ipywidgets 
+ipython==8.12.1
 git+https://github.com/XENONnT/inference_interface@v0.0.0
 jedi==0.17.2                                       # upgrading to 0.18.0 breaks autocomplete in ipython
 jupyter==1.0.0


### PR DESCRIPTION
From `ipython==8.13.0`, it stops supporting `python==3.8` or lower versions. 

https://github.com/ipython/ipython/blob/02bab11e7a2cd15670c17f6c8587f0609eb61961/IPython/__init__.py#L29