### PR TITLE
Enable local cutax in Midway3

### DIFF
--- a/create-env
+++ b/create-env
@@ -239,10 +239,11 @@ if [ -e \$config_path ]; then
 fi
 
 # grab a local cutax installation if we have one
-MIDWAY_CUTAX_DIR=/dali/lgrandi/xenonnt/software/cutax/${cutax_version}
+MIDWAY2_CUTAX_DIR=/dali/lgrandi/xenonnt/software/cutax/${cutax_version}
+MIDWAY3_CUTAX_DIR=/project2/lgrandi/xenonnt/dali/lgrandi/xenonnt/software/cutax/${cutax_version}
 OSG_CUTAX_DIR=/xenon/xenonnt/software/cutax/${cutax_version}
 if [ "x\${CUTAX_LOCATION}" = "x" ]; then
-  for dir in \${MIDWAY_CUTAX_DIR} \${OSG_CUTAX_DIR}; do
+  for dir in \${MIDWAY3_CUTAX_DIR} \${MIDWAY2_CUTAX_DIR} \${OSG_CUTAX_DIR}; do
     if [ -e \$dir ]; then
        CUTAX_LOCATION=\$dir
     fi


### PR DESCRIPTION
Triggered by [this issue in env_starter](https://github.com/XENONnT/env_starter/issues/29). The issue is that from midway3 you don't have access to `/dali`. [This loop](https://github.com/XENONnT/base_environment/blob/17b1e82dc0856ac4c8cb0e803f244a1d9ffd95d3/create-env#L244-L249) will lead to empty `CUTAX_LOCATION` on midway3, because you have no access to either `/dali` or `/xenon`.

Note that we put `MIDWAY3_CUTAX_DIR` in front of `MIDWAY2_CUTAX_DIR`, so that even though you are on dali you won't end up with a cutax in `/project2`。