### PR TITLE
Bump utilix from 0.7.2 to 0.7.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -85,7 +85,7 @@ tensorflow==2.12.0
 tensorflow_probability==0.20.1
 tqdm==4.65.0
 typing_extensions==4.6.3                           # Tensorflow and bokeh dependency
-utilix==0.7.2                                      # dependency for straxen, admix
+utilix==0.7.4                                      # dependency for straxen, admix
 wfsim==1.0.2
 xarray==2023.5.0
 xe-admix==1.0.9


### PR DESCRIPTION
So that people don't have to install utilix locally themselves. 0.7.2 doesn't bind the storage for you so it doesn't suit the midway-deli status.