### PR TITLE
Updated base image to htc/centos:7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensciencegrid/osgvo-el7
+FROM hub.opensciencegrid.org/htc/centos:7
 
 LABEL opensciencegrid.name="XENONnT"
 LABEL opensciencegrid.description="Base software environment for XENONnT, including Python 3.9 and data management tools"


### PR DESCRIPTION
This is an important change as hub.opensciencegrid.org/htc/centos:7 is kept updated where as the old osgvo-el7 image is not frequently updated