### PR TITLE
New OSG cutax location

### DIFF
--- a/create-env
+++ b/create-env
@@ -240,7 +240,7 @@ fi
 
 # grab a local cutax installation if we have one
 MIDWAY_CUTAX_DIR=/dali/lgrandi/xenonnt/software/cutax/${cutax_version}
-OSG_CUTAX_DIR=/xenon/xenonnt/software/cutax/${cutax_version}
+OSG_CUTAX_DIR=/ospool/uc-shared/project/xenon/xenonnt/software/cutax/${cutax_version}
 if [ "x\${CUTAX_LOCATION}" = "x" ]; then
   for dir in \${MIDWAY_CUTAX_DIR} \${OSG_CUTAX_DIR}; do
     if [ -e \$dir ]; then


### PR DESCRIPTION
Since `/xenon` will be replaced by `/ospool/uc-shared/project/xenon`, we need to redirect our cutax to the new location.