### PR TITLE
Bump pema from 0.6.4 to 0.6.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ pandoc==2.3
 panel==0.14.4
 parso==0.7.1                                       # upgrading to 0.8.0 breaks autocomplete in ipython
 pdmongo==0.3.4                                     # strax dependency
-pema==0.6.4
+pema==0.6.5
 pika==1.3.2                                        # Pegasus
 prettytable==3.7.0
 poetry==1.5.1


### PR DESCRIPTION
So that we can bypass the bugs due to negative length in wfsim truth