### PR TITLE
Don't use _include_rucio_remote in simulation contexts

### DIFF
--- a/.github/scripts/update-context-collection.py
+++ b/.github/scripts/update-context-collection.py
@@ -32,10 +32,13 @@ def main():
     for context in context_list:
         # pass cut_list=None so that we don't track the cut lineages. They aren't saved anyway
         # skip contexts that raise errors
-        
+            
         try:
-            st = getattr(cutax.contexts, context)(cut_list=None,
-                                                  _include_rucio_remote=True)
+            if 'sim' in context:
+                st = getattr(cutax.contexts, context)(cut_list=None)
+            else:
+                st = getattr(cutax.contexts, context)(cut_list=None,
+                                                      _include_rucio_remote=True)
         except NotImplementedError:
             print(f"Skipping {context}")
             continue


### PR DESCRIPTION
The `update-context-collection.py` test seems to fail because it tries to use `_include_rucio_remote` in declaring simulation contexts which do not have this keyword argument. This pull request checks to see if the context is a simulation context and does not include the `_include_rucio_remote` argument if it is.