### PR TITLE
Groups to dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,11 @@ updates:
   - dependency-name: jedi
     versions:
     - "> 0.17.2, < 1"
+  groups:
+    numba:
+      patterns:
+        - "numba"
+        - "llvmlite"
+    patches:
+      update-types:
+        - "patch"


### PR DESCRIPTION
## Dependabot groups
One can use [dependabot groups](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) to decrease the number of opened pull requests.

In this simple example, I've grouped all the patches and numba versions together. This will result in:
1.  For all the patch versions: one PR
2.  For each minor or major version that can be updated: one PR
3.  For all the numba related packages: one PR

### Intended effect
So instead of having ~50 PRs/month you'll probably have only a hand full, depending mostly on the number of minor/major versions that were released.

Especially `1.` can really reduce the number of trivial dependencies that you can probably easily merge. Even if one of the dependencies is incompatibly, you can easily have dependabot discard that specific one after looking into the logs. See the above mentioned PR where I omitted `pycairo`.

### Example
I've added it recently to one of my modules and an example of the patch PR can be found here:
https://github.com/JoranAngevaare/optim_esm_base/pull/316

Hope you guys are doing well, cheers, Joran