### PR TITLE
Downgrade rucio to wait for rucio server upgrade

### DIFF
--- a/create-env
+++ b/create-env
@@ -6,7 +6,7 @@
 
 gfal2_bindings_version=1.12.2
 gfal2_util_version=1.8.1
-rucio_version=1.31.7
+rucio_version=1.23.14
 ## REMEMBER THE 'v' IN CUTAX_VERSION!! (unless it is 'latest')
 cutax_version=v1.16.0
 #######################################################################


### PR DESCRIPTION
Original discussion [here](https://xenonnt.slack.com/archives/C048FE2U3KN/p1706725791616439): we have to wait til rucio server has been updated to upgrade rucio version.