### PR TITLE
Remove MC packages

### DIFF
--- a/.github/scripts/do_all_tests.sh
+++ b/.github/scripts/do_all_tests.sh
@@ -9,7 +9,7 @@ echo '/home/.github' `ls /home/.github`
 echo '$HOME' $HOME
 
 # FIXME add XEDOCS
-for package in strax straxen wfsim pema cutax appletree alea-inference admix gfal;
+for package in strax straxen appletree alea-inference admix gfal;
 do
   echo testing $package;
   bash .github/scripts/do_tests.sh $package;

--- a/.github/scripts/do_tests.sh
+++ b/.github/scripts/do_tests.sh
@@ -45,25 +45,6 @@ case "$1" in
     rm $HOME/pre_apply_function.py
   ;;
 
-  wfsim )
-    # wfsim
-    echo " ... wfsim tests"
-    wfsim_version=`python -c "import wfsim; print(wfsim.__version__)"`
-    echo "Testing $wfsim_version"
-    git clone --single-branch --branch v$wfsim_version https://github.com/XENONnT/wfsim ./wfsim
-    pytest -v wfsim || { echo 'wfsim tests failed' ; exit 1; }
-    rm -r wfsim
-  ;;
-
-  pema )
-    echo " ... pema tests"
-    pema_version=`python -c "import pema; print(pema.__version__)"`
-    echo "Testing $pema_version"
-    git clone --single-branch --branch v$pema_version https://github.com/XENONnT/pema ./pema
-    pytest -v pema || { echo 'pema tests failed' ; exit 1; }
-    rm -r pema
-  ;;
-
   cutax )
     # cutax
     # we have already checked out cutax in the actions workflow

--- a/.github/scripts/do_tests.sh
+++ b/.github/scripts/do_tests.sh
@@ -73,6 +73,7 @@ case "$1" in
 
     CUTAX_VERSION=$(grep "cutax_version=" create-env)
     CUTAX_VERSION=${CUTAX_VERSION//cutax_version=}
+    unset ALLOW_MC_TEST
     echo "Testing with cutax version ${CUTAX_VERSION}"
     cd cutax
     if [ $CUTAX_VERSION != 'latest' ]

--- a/.github/workflows/test_ax.yml
+++ b/.github/workflows/test_ax.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
-        package: [ 'strax', 'straxen', 'wfsim', 'pema', 'cutax', 'appletree', 'alea-inference' ]
+        package: [ 'strax', 'straxen', 'cutax', 'appletree', 'alea-inference' ]
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'XENONnT' && github.triggering_actor != 'dependabot[bot]' }}
     steps:
@@ -79,5 +79,5 @@ jobs:
           DISABLE_RUCIO_TEST: 1
         run: |
           source /cvmfs/xenon.opensciencegrid.org/releases/nT/development/setup.sh
-          straxen-print_versions strax straxen wfsim cutax appletree alea-inference npshmex numba numpy nton admix
+          straxen-print_versions strax straxen cutax appletree alea-inference npshmex numba numpy nton admix
           bash .github/scripts/do_tests.sh ${{matrix.package}}

--- a/create-env
+++ b/create-env
@@ -8,7 +8,7 @@ gfal2_bindings_version=1.12.2
 gfal2_util_version=1.8.1
 rucio_version=1.23.14
 ## REMEMBER THE 'v' IN CUTAX_VERSION!! (unless it is 'latest')
-cutax_version=v1.16.0
+cutax_version=latest
 #######################################################################
 
 set -e

--- a/create-env
+++ b/create-env
@@ -8,7 +8,7 @@ gfal2_bindings_version=1.12.2
 gfal2_util_version=1.8.1
 rucio_version=1.23.14
 ## REMEMBER THE 'v' IN CUTAX_VERSION!! (unless it is 'latest')
-cutax_version=latest
+cutax_version=v1.16.1
 #######################################################################
 
 set -e

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ comm==0.2.1
 corner==2.2.2
 cython==0.29.35
 emcee==3.1.4
-epix==0.3.6
 flamedisx==2.0.0
 future==0.18.3
 GOFevaluation==0.1.3
@@ -30,13 +29,11 @@ line-profiler==4.0.3
 mergedeep==1.3.4
 ml-dtypes==0.2.0
 nbsphinx==0.9.3
-nestpy==2.0.0                                      # WFSim/epix dependency - do not update unless validated
 notebook==7.0.6
 numpy==1.26.3
 numpyro==0.13.2
 pandoc==2.3
 parso==0.8.3                                       # upgrading to 0.8.0 breaks autocomplete in ipython
-pema==0.7.0
 pika==1.3.2                                        # Pegasus
 prettytable==3.9.0
 pre-commit==3.6.0
@@ -53,6 +50,5 @@ strax==1.6.0
 straxen==2.2.0
 tables==3.9.2                                      # pytables, necessary for pandas hdf5 i/o
 tensorflow-probability==0.23.0
-wfsim==1.2.0
 xe-admix==1.0.14
 xgboost==2.0.3


### PR DESCRIPTION
epix, nestpy, pema and wfsim will be removed from base_environment from the next release on, and will be present in the montecarlo_environment only, pending approval by the tools maintainers and ACs.