### PR TITLE
Update Some Dependencies

### DIFF
--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -1,23 +1,23 @@
-awkward==2.5.1
+awkward==2.6.1                                     # Feb 2.5.1
 blosc==1.11.1                                      # strax dependency
 bokeh==3.2.2
 boltons==23.1.1
 commentjson==0.9.0                                 # straxen dependency
 coverage==6.5.0
 coveralls==3.3.1
-dask==2024.1.0
+dask==2024.2.0                                     # Feb 2024.1.0
 dask-jobqueue==0.8.2
 datashader==0.16.0
-dill==0.3.7                                        # strax dependency
+dill==0.3.8                                        # strax dependency 0.3.7
 flake8==7.0.0
 GitPython==3.1.41                                  # Pegasus dependency
 holoviews==1.18.1
-hypothesis==6.93.0
+hypothesis==6.98.4                                 # Feb 6.93.0
 immutabledict==2.2.3
 ipywidgets==8.1.1                                  # For online monitoring
 Jinja2==3.1.3
 jupyter-client==8.6.0
-keras==2.15.0
+keras==2.15.0                                      
 lz4==4.3.3                                         # strax dependency
 matplotlib==3.8.2
 memory-profiler==0.61.0
@@ -25,25 +25,25 @@ mongomock==4.1.2
 multihist==0.6.5
 nbmake==1.4.1
 npshmex==0.2.1                                     # strax dependency
-numba==0.58.1                                      # strax dependency
+numba==0.59.0                                      # strax dependency 0.58.1
 numexpr==2.8.8
 packaging==23.2
-pandas==1.5.3
+pandas==1.5.3                                      # Feb 1.5.3
 panel==1.2.3
 pdmongo==0.3.4                                     # strax dependency
-psutil==5.9.7                                      # strax dependency
+psutil==5.9.8                                      # strax dependency Feb 5.9.7
 pymongo==4.3.3
-pytest==7.4.4
+pytest==8.0.0                                      # Feb 7.4.4
 pytest-cov==4.0.0
 pytest-xdist==3.2.0
-scikit-learn==1.2.2
-scipy==1.11.4
-tensorflow==2.15.0
+scikit-learn==1.4.0                                # Feb 1.2.2
+scipy==1.12.0                                      # Feb 1.11.4                             
+tensorflow==2.15.0                           
 typing-extensions==4.9.0                           # Tensorflow and bokeh dependency
 tqdm==4.66.1
-uproot==5.2.1
+uproot==5.2.2                                      # Feb 5.2.1
 utilix==0.7.7                                      # dependency for straxen, admix
-xarray==2023.12.0
-xedocs==0.2.25
+xarray==2024.1.1                                   # Feb 2023.12.0
+xedocs==0.2.26                                     # Feb 0.2.25
 zarr==2.14.1
 zstd==1.5.5.1                                      # strax dependency

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,29 +6,29 @@ blueice==1.2.0
 codenamize==1.2.3                                  # for human-readable hashing
 comm==0.2.1
 corner==2.2.2
-cython==0.29.35
+cython==3.0.8                                      # Feb 0.29.35
 emcee==3.1.4
 epix==0.3.6
 flamedisx==2.0.0
 future==0.18.3
 GOFevaluation==0.1.3
 h5py==3.10.0
-iminuit==2.24.0
+iminuit==2.25.2                                    # Feb 2.24.0
 inference-interface==0.0.2
 ipykernel==6.28.0                                  # For ipywidgets
 ipympl==0.9.3                                      # For online monitoring
-ipython==8.12.1
+ipython==8.12.1                                    # Feb 8.12.1
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 jax[cuda12_pip]==0.4.23
 jedi==0.19.1                                       # upgrading to 0.18.0 breaks autocomplete in ipython
 jupyter==1.0.0
-jupyterlab==4.0.10
+jupyterlab==4.0.10                                 
 jupyterlab-widgets==3.0.9
 jupyter-resource-usage==1.0.1                      # Memory viewer for notebooks
-lightgbm==4.2.0
-line-profiler==4.0.3
+lightgbm==4.3.0                                    # Feb 4.2.0
+line-profiler==4.1.2                               # Feb 4.0.3
 mergedeep==1.3.4
-ml-dtypes==0.2.0
+ml-dtypes==0.3.2                                   # Feb 0.2.0
 nbsphinx==0.9.3
 nestpy==2.0.0                                      # WFSim/epix dependency - do not update unless validated
 notebook==7.0.6
@@ -41,10 +41,10 @@ pika==1.3.2                                        # Pegasus
 prettytable==3.9.0
 pre-commit==3.6.0
 poetry==1.7.1
-pyarrow==14.0.2                                    # Necessary for pandas feather i/o
+pyarrow==15.0.0                                    # Necessary for pandas feather i/o Feb 14.0.2
 pytest-runner==6.0.1
 reprox==0.2.2
-seaborn==0.13.1
+seaborn==0.13.2                                    # Feb 0.13.1
 sharedarray==3.2.2
 snakeviz==2.2.0
 sphinx==7.0.1


### PR DESCRIPTION
cython 0.29.35->3.0.8
GOFevaluation 0.1.3->0.1.4
iminuit 2.24.0->2.25.2
lightgbm 4.2.0->4.3.0
line-profiler 4.0.3->4.1.2
ml-dtypes 0.2.0->0.3.2
pyarrow 14.0.2->15.0.0
seaborn  0.13.1->0.13.2
awkward 2.5.1->2.6.1
dask 2024.1.0->2024.2.0
dill 0.3.7->0.3.8
hypothesis 6.93.0->6.98.4
numba 0.58.1->0.59.0 
psutil 5.9.7->5.9.8
pytest 7.4.4->8.0.0
scikit-learn 1.2.2->1.4.0
scipy 1.11.4->1.12.0
uproot 5.2.1->5.2.2
xarray 2023.12.0->2024.1.1
xedocs 0.2.25->0.2.26