### PR TITLE
Bump cutax to v1.17.1

### DIFF
--- a/create-env
+++ b/create-env
@@ -8,7 +8,7 @@ gfal2_bindings_version=1.12.2
 gfal2_util_version=1.8.1
 rucio_version=32.8.0
 ## REMEMBER THE 'v' IN CUTAX_VERSION!! (unless it is 'latest')
-cutax_version=v1.16.1
+cutax_version=v1.17.0
 #######################################################################
 
 set -e

--- a/create-env
+++ b/create-env
@@ -8,7 +8,7 @@ gfal2_bindings_version=1.12.2
 gfal2_util_version=1.8.1
 rucio_version=32.8.0
 ## REMEMBER THE 'v' IN CUTAX_VERSION!! (unless it is 'latest')
-cutax_version=v1.17.0
+cutax_version=v1.17.1
 #######################################################################
 
 set -e

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -37,7 +37,7 @@ pymongo==4.3.3
 pytest==8.0.2                                      
 pytest-cov==4.1.0
 pytest-xdist==3.5.0
-scikit-learn==1.4.1.post1                               
+scikit-learn==1.2.2                               
 scipy==1.12.0                                                                   
 tensorflow==2.15.0.post1                           
 typing-extensions==4.10.0                           # Tensorflow and bokeh dependency

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -13,7 +13,7 @@ dill==0.3.8                                        # strax dependency
 flake8==7.0.0
 GitPython==3.1.42                                  # Pegasus dependency
 holoviews==1.18.3
-hypothesis==6.98.11                                 
+hypothesis==6.98.15                                 
 immutabledict== 4.1.0
 ipywidgets==8.1.2                                  # For online monitoring
 Jinja2==3.1.3
@@ -40,7 +40,7 @@ pytest-xdist==3.5.0
 scikit-learn==1.2.2                               
 scipy==1.12.0                                                                   
 tensorflow==2.15.0.post1                           
-typing-extensions==4.9.0                           # Tensorflow and bokeh dependency
+typing-extensions==4.10.0                           # Tensorflow and bokeh dependency
 tqdm==4.66.2
 uproot==5.3.1                                      
 utilix==0.7.7                                      # dependency for straxen, admix

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -3,7 +3,7 @@ blosc==1.11.1                                      # strax dependency
 bokeh==3.2.2
 boltons==23.1.1
 commentjson==0.9.0                                 # straxen dependency
-coverage==6.5.0
+coverage==6.5.0                                    # coveralls prevent further update
 coveralls==3.3.1
 dask==2024.2.0                                     
 dask-jobqueue==0.8.5
@@ -18,7 +18,7 @@ immutabledict== 4.1.0
 ipywidgets==8.1.2                                  # For online monitoring
 Jinja2==3.1.3
 jupyter-client==8.6.0
-keras==2.15.0                                      
+keras==2.15.0                                      # tensorflow 2.15.0 depends on keras2.16 and=2.15.0
 lz4==4.3.3                                         # strax dependency
 matplotlib==3.8.3
 memory-profiler==0.61.0
@@ -29,15 +29,15 @@ npshmex==0.2.1                                     # strax dependency
 numba==0.59.0                                      # strax dependency 
 numexpr==2.9.0
 packaging==23.2
-pandas==1.5.3                                      
-panel==1.2.3
+pandas==1.5.3                                      # pdmongo 0.3.4 requires pandas<1.6
+panel==1.2.3                                       # upgrading it causes conflict with xeauth
 pdmongo==0.3.4                                     # strax dependency
 psutil==5.9.8                                      # strax dependency 
 pymongo==4.3.3
 pytest==8.0.2                                      
 pytest-cov==4.1.0
 pytest-xdist==3.5.0
-scikit-learn==1.2.2                               
+scikit-learn==1.4.1.post1                               
 scipy==1.12.0                                                                   
 tensorflow==2.15.0.post1                           
 typing-extensions==4.10.0                           # Tensorflow and bokeh dependency

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ GOFevaluation==0.1.4
 h5py==3.10.0
 iminuit==2.25.2                                    
 inference-interface==0.0.2
-ipykernel==6.29.2                                  # For ipywidgets
+ipykernel==6.29.3                                  # For ipywidgets
 ipympl==0.9.3                                      # For online monitoring
 ipython==8.12.1                                    
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
@@ -29,6 +29,7 @@ line-profiler==4.1.2
 mergedeep==1.3.4
 ml-dtypes==0.2.0                                   
 nbsphinx==0.9.3
+nestpy==2.0.2
 notebook==7.0.8                                   # <7.1.0 for compatibility with jupyterlab 4.0.12
 numpy==1.26.4
 numpyro==0.13.2
@@ -37,7 +38,7 @@ parso==0.8.3                                       # upgrading to 0.8.0 breaks a
 pika==1.3.2                                        # Pegasus
 prettytable==3.10.0
 pre-commit==3.6.2
-poetry==1.7.1
+poetry==1.8.1
 pyarrow==15.0.0                                    # Necessary for pandas feather i/o 
 pytest-runner==6.0.1
 reprox==0.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ jupyter-resource-usage==1.0.1                      # Memory viewer for notebooks
 lightgbm==4.3.0                                    
 line-profiler==4.1.2                               
 mergedeep==1.3.4
-ml-dtypes==0.2.0                                   
+ml-dtypes==0.2.0                                  # tensorflow 2.15.0.post1 requires ml-dtypes~=0.2.0
 nbsphinx==0.9.3
 nestpy==2.0.2
 notebook==7.0.8                                   # <7.1.0 for compatibility with jupyterlab 4.0.12


### PR DESCRIPTION
Added back nestpy==2.0.2 (see this thread - https://xenonnt.slack.com/archives/C016DM0JPK9/p1710926522013399)
cutax: 1.16.1->1.17.1

extra_requirements/requirements-tests.txt:
hypothesis: 6.98.11 -> 6.98.15
scikit-learn: 1.2.2 -> 1.4.1.post1
typing-extensions: 4.9.0 -> 4.10.0

requirements.txt:
ipykernel: 6.29.2 -> 6.29.3
poetry: 1.7.1 -> 1.8.1