### PR TITLE
Bump utilix from v0.7.7 to v0.8.0

### DIFF
--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -43,7 +43,7 @@ tensorflow==2.15.0.post1
 typing-extensions==4.10.0                           # Tensorflow and bokeh dependency
 tqdm==4.66.2
 uproot==5.3.1                                      
-utilix==0.7.7                                      # dependency for straxen, admix
+utilix==0.8.0                                   # dependency for straxen, admix
 xarray==2024.2.0                                   
 xedocs==0.2.26                                     
 zarr==2.17.0


### PR DESCRIPTION
So that we have the refactored batchq feature as well as the handling of `lc` nodes on `xenon1t` partition.