### PR TITLE
Install flake8 and black

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ alea-inference==0.2.3
 appletree[cpu]==0.3.1
 astropy==6.0.0
 atomicwrites==1.4.1
+black==24.3.0
 blueice==1.2.0
 codenamize==1.2.3                                  # for human-readable hashing
 comm==0.2.1
@@ -9,6 +10,7 @@ corner==2.2.2
 cython==3.0.8
 emcee==3.1.4
 flamedisx==2.0.0
+flake8==7.0.0
 future==1.0.0
 GOFevaluation==0.1.4
 h5py==3.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ corner==2.2.2
 cython==3.0.8
 emcee==3.1.4
 flamedisx==2.0.0
-flake8==7.0.0
 future==1.0.0
 GOFevaluation==0.1.4
 h5py==3.10.0


### PR DESCRIPTION
Add black v24.3.0 into requirement.txt. flake8 is already in the requirements_tests.txt