### PR TITLE
Regular Upgrade of Packages

### DIFF
--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -14,7 +14,7 @@ flake8==7.0.0
 GitPython==3.1.43                                  # Pegasus dependency
 graphviz==0.20.3
 holoviews==1.18.3
-hypothesis==6.100.5
+hypothesis==6.100.1
 immutabledict== 4.2.0
 ipywidgets==8.1.2                                  # For online monitoring
 Jinja2==3.1.4

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -1,23 +1,23 @@
-awkward==2.6.3
+awkward==2.6.4
 blosc==1.11.1                                      # strax dependency
-bokeh==3.2.2
+bokeh==3.2.2                                       # panel 1.2.3 depends on bokeh<3.3.0 and >=3.1.1
 boltons==24.0.0
 commentjson==0.9.0                                 # straxen dependency
 coverage==6.5.0                                    # coveralls prevent further update
 coveralls==3.3.1
-dask==2024.4.1
+dask==2024.5.0
 dask-jobqueue==0.8.5
-datashader==0.16.0
+datashader==0.16.1
 deepdiff==7.0.1
 dill==0.3.8                                        # strax dependency
 flake8==7.0.0
 GitPython==3.1.43                                  # Pegasus dependency
 graphviz==0.20.3
 holoviews==1.18.3
-hypothesis==6.100.1
+hypothesis==6.100.5
 immutabledict== 4.2.0
 ipywidgets==8.1.2                                  # For online monitoring
-Jinja2==3.1.3
+Jinja2==3.1.4
 jupyter-client==8.6.0
 keras==2.15.0                                      # tensorflow 2.15.0 depends on keras2.16 and=2.15.0
 lz4==4.3.3                                         # strax dependency
@@ -29,23 +29,23 @@ nbmake==1.5.3
 npshmex==0.2.1                                     # strax dependency
 numba==0.59.1                                      # strax dependency
 numexpr==2.10.0
-packaging==23.2
+packaging==24.0
 pandas==1.5.3                                      # pdmongo 0.3.4 requires pandas<1.6
 panel==1.2.3                                       # upgrading it causes conflict with xeauth
 pdmongo==0.3.4                                     # strax dependency
 psutil==5.9.8                                      # strax dependency
 pymongo==3.13.0                                    # don't upgrade it
-pytest==8.1.1
+pytest==8.2.0
 pytest-cov==5.0.0
-pytest-xdist==3.5.0
-scikit-learn==1.2.2
+pytest-xdist==3.6.1
+scikit-learn==1.4.2
 scipy==1.13.0
 tensorflow==2.15.0.post1
 typing-extensions==4.10.0                          # Tensorflow and bokeh dependency
-tqdm==4.66.2
-uproot==5.3.3
-utilix==0.8.0                                      # dependency for straxen, admix
+tqdm==4.66.4
+uproot==5.3.6
+utilix==0.8.3                                      # dependency for straxen, admix
 xarray==2024.3.0
 xedocs==0.2.27
-zarr==2.17.2
+zarr==2.18.0
 zstd==1.5.5.1                                      # strax dependency

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -14,7 +14,7 @@ flake8==7.0.0
 GitPython==3.1.43                                  # Pegasus dependency
 graphviz==0.20.3
 holoviews==1.18.3
-hypothesis==6.100.1
+hypothesis==6.100.5
 immutabledict== 4.2.0
 ipywidgets==8.1.2                                  # For online monitoring
 Jinja2==3.1.4
@@ -35,9 +35,9 @@ panel==1.2.3                                       # upgrading it causes conflic
 pdmongo==0.3.4                                     # strax dependency
 psutil==5.9.8                                      # strax dependency
 pymongo==3.13.0                                    # don't upgrade it
-pytest==8.2.0
+pytest==8.1.1
 pytest-cov==5.0.0
-pytest-xdist==3.5.0
+pytest-xdist==3.6.1
 scikit-learn==1.2.2
 scipy==1.13.0
 tensorflow==2.15.0.post1

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -37,7 +37,7 @@ psutil==5.9.8                                      # strax dependency
 pymongo==3.13.0                                    # don't upgrade it
 pytest==8.1.1
 pytest-cov==5.0.0
-pytest-xdist==3.6.1
+pytest-xdist==3.5.0
 scikit-learn==1.2.2
 scipy==1.13.0
 tensorflow==2.15.0.post1

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -38,7 +38,7 @@ pymongo==3.13.0                                    # don't upgrade it
 pytest==8.2.0
 pytest-cov==5.0.0
 pytest-xdist==3.6.1
-scikit-learn==1.4.2
+scikit-learn==1.2.2
 scipy==1.13.0
 tensorflow==2.15.0.post1
 typing-extensions==4.10.0                          # Tensorflow and bokeh dependency

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -37,7 +37,7 @@ psutil==5.9.8                                      # strax dependency
 pymongo==3.13.0                                    # don't upgrade it
 pytest==8.2.0
 pytest-cov==5.0.0
-pytest-xdist==3.6.1
+pytest-xdist==3.5.0
 scikit-learn==1.2.2
 scipy==1.13.0
 tensorflow==2.15.0.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ ipykernel==6.29.4                                  # For ipywidgets
 ipympl==0.9.4                                      # For online monitoring
 ipython==8.18.1
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-jax[cuda12_pip]==0.4.27
+jax[cuda12_pip]==0.4.24
 jedi==0.19.1                                       
 jupyter==1.0.0
 jupyterlab==4.0.12                                 # <4.1.0 for compatibility with xeauth 0.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,13 +2,13 @@ alea-inference==0.2.3
 appletree[cpu]==0.3.2
 astropy==6.0.1
 atomicwrites==1.4.1
-black==24.3.0
+black==24.4.2
 blueice==1.2.0
 codenamize==1.2.3                                  # for human-readable hashing
 comm==0.2.2
 corner==2.2.2
 cython==3.0.10
-emcee==3.1.4
+emcee==3.1.6
 flamedisx==2.1.0
 future==1.0.0
 GOFevaluation==0.1.4
@@ -16,20 +16,20 @@ h5py==3.11.0
 iminuit==2.25.2
 inference-interface==0.0.2
 ipykernel==6.29.4                                  # For ipywidgets
-ipympl==0.9.3                                      # For online monitoring
+ipympl==0.9.4                                      # For online monitoring
 ipython==8.18.1
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-jax[cuda12_pip]==0.4.24
-jedi==0.19.1                                       # upgrading to 0.18.0 breaks autocomplete in ipython
+jax[cuda12_pip]==0.4.27
+jedi==0.19.1                                       
 jupyter==1.0.0
 jupyterlab==4.0.12                                 # <4.1.0 for compatibility with xeauth 0.2.3
 jupyterlab-widgets==3.0.10
 jupyter-resource-usage==1.0.2                      # Memory viewer for notebooks
 lightgbm==4.3.0
-line-profiler==4.1.2
+line-profiler==4.1.3
 mergedeep==1.3.4
 ml-dtypes==0.2.0                                   # tensorflow 2.15.0.post1 requires ml-dtypes~=0.2.0
-nbsphinx==0.9.3
+nbsphinx==0.9.4
 nestpy==2.0.2
 notebook==7.0.8                                    # <7.1.0 for compatibility with jupyterlab 4.0.12
 numpy==1.26.4
@@ -39,7 +39,7 @@ parso==0.8.4                                       # upgrading to 0.8.0 breaks a
 pika==1.3.2                                        # Pegasus
 prettytable==3.10.0
 pre-commit==3.7.0
-poetry==1.8.2
+poetry==1.8.3
 pyarrow==15.0.2                                    # Necessary for pandas feather i/o
 pydantic==1.10.14                                  # utilix dependency
 pytest-runner==6.0.1
@@ -49,10 +49,10 @@ seaborn==0.13.2
 simple-slurm==0.2.7
 sharedarray==3.2.3
 snakeviz==2.2.0
-sphinx==7.2.6
-statsmodels==0.14.1
-strax==1.6.2
-straxen==2.2.1
+sphinx==7.3.7
+statsmodels==0.14.2
+strax==1.6.3
+straxen==2.2.2
 tables==3.9.2                                      # pytables, necessary for pandas hdf5 i/o
 tensorflow-probability==0.24.0
 timeout_decorator==0.5.0                           # needed by fuse


### PR DESCRIPTION
Routine upgrade of packages according to pip-review
Jax is still not updated since v0.4.27 can cause conflict with Numba? ValueError: Jitted function has static_argnums=(3, 4), but only accepts 4 positional arguments.