### PR TITLE
Bump Xedocs version to 0.2.28

### DIFF
--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -46,6 +46,6 @@ tqdm==4.66.4
 uproot==5.3.6
 utilix==0.8.3                                      # dependency for straxen, admix
 xarray==2024.3.0
-xedocs==0.2.27
+xedocs==0.2.28
 zarr==2.18.0
 zstd==1.5.5.1                                      # strax dependency


### PR DESCRIPTION
Bumping xedocs to new release ([0.2.28](https://github.com/XENONnT/xedocs/releases/tag/v0.2.28)) in the base_env