### PR TITLE
rocky9 base container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensciencegrid/osgvo-el7
+FROM hub.opensciencegrid.org/htc/rocky:9
 
 LABEL opensciencegrid.name="XENONnT"
 LABEL opensciencegrid.description="Base software environment for XENONnT, including Python 3.9 and data management tools"
@@ -12,16 +12,13 @@ RUN echo "Building Docker container for XENONnT_${XENONnT_TAG} ..."
 
 RUN yum-config-manager --disable Pegasus
 
-RUN yum -y clean all && yum -y --skip-broken upgrade
+RUN dnf -y clean all && dnf -y --skip-broken upgrade
 
-RUN  yum -y install centos-release-scl && \
-     yum -y install \
+RUN dnf -y install \
             cmake \
             davix-devel \
             dcap-devel \
-            devtoolset-9 \
             doxygen \
-            dpm-devel \
             gfal2-all \
             gfal2-devel \
             gfal2-plugin-file \
@@ -35,7 +32,6 @@ RUN  yum -y install centos-release-scl && \
             graphviz \
             gtest-devel \
             json-c-devel \
-            lfc-devel \
             libarchive \
             libattr-devel \
             libffi-devel \
@@ -47,7 +43,6 @@ RUN  yum -y install centos-release-scl && \
             zlib-devel \
             nano \
             bash-completion \
-            bash-completion-extras \
     && \
     yum clean all && \
     localedef -i en_US -f UTF-8 en_US.UTF-8
@@ -56,13 +51,12 @@ ADD create-env conda_xnt.yml requirements.txt /tmp/
 
 COPY extra_requirements/requirements-tests.txt /tmp/extra_requirements/requirements-tests.txt
 
-RUN source /opt/rh/devtoolset-9/enable && \
-    cd /tmp && \
+RUN cd /tmp && \
     bash create-env /opt/XENONnT ${XENONnT_TAG} && \
     rm -f create-env conda_xnt.yml
 
 # relax permissions so we can build cvmfs tar balls
-RUN chmod 1777 /cvmfs
+RUN mkdir -p /cvmfs && chmod 1777 /cvmfs
 
 COPY labels.json /.singularity.d/
 

--- a/create-env
+++ b/create-env
@@ -110,15 +110,18 @@ git clone https://gitlab.cern.ch/dmc/gfal2-bindings.git
 cd gfal2-bindings
 git checkout v$gfal2_bindings_version
 perl -p -i -e "s;.*\\\${Boost_LIBRARYDIR};            \"${target_dir}/anaconda/envs/${env_name}/lib\";" CMakeLists.txt
+export CXXFLAGS=-I${target_dir}/anaconda/envs/${env_name}/include
 cmake -DPYTHON_EXECUTABLE=${target_dir}/anaconda/envs/${env_name}/bin/python3.9 \
       -DPYTHON_EXECUTABLE_3=${target_dir}/anaconda/envs/${env_name}/bin/python3.9 \
       -DPYTHON_EXECUTABLE_3.9=${target_dir}/anaconda/envs/${env_name}/bin/python3.9 \
       -DBOOST_ROOT=${target_dir}/anaconda/envs/${env_name} \
-      -DSKIP_DOC=TRUE -DSKIP_TESTS=TRUE
+      -DSKIP_DOC=TRUE -DSKIP_TESTS=TRUE \
+      -DCMAKE_RULE_MESSAGES=OFF
 make
 make install
 cd ${target_dir}
 rm -rf gfal2-bindings
+unset CXXFLAGS
 
 # gfal2 clients
 announce "Installing GFAL2 clients"


### PR DESCRIPTION
As discussed a couple of times in the past, the base_environment is currently based on RHEL7, which is out of support and now longer get updates (neither from the OS vendor, nor OSG). We need to update to RHEL9. This builds fine, but the stack needs testing.