### PR TITLE
Updated xedocs requirement

### DIFF
--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -41,6 +41,7 @@ pymongo==3.13.0                                    # don't upgrade it
 pytest==8.2.2
 pytest-cov==5.0.0
 pytest-xdist==3.6.1
+rframe==0.2.21
 scikit-learn==1.2.2
 scipy==1.13.1
 tensorflow==2.15.0.post1

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -49,6 +49,6 @@ tqdm==4.66.4
 uproot==5.3.6
 utilix==0.8.5                                      # dependency for straxen, admix
 xarray==2024.3.0
-xedocs==0.2.28
+xedocs==0.2.29
 zarr==2.18.0
 zstd==1.5.5.1                                      # strax dependency


### PR DESCRIPTION
Latest xedocs release is [v0.2.29](https://github.com/XENONnT/xedocs/)