### PR TITLE
Try using vault.centos.org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ LABEL opensciencegrid.url="http://www.xenon1t.org/"
 LABEL opensciencegrid.category="Project"
 LABEL opensciencegrid.definition_url="https://github.com/XENONnT/base_environment"
 
+# Set up the repository to use vault.centos.org
+RUN sed -i 's|mirrorlist=http://mirrorlist.centos.org|#mirrorlist=http://mirrorlist.centos.org|' /etc/yum.repos.d/CentOS-*.repo && \
+    sed -i 's|#baseurl=http://vault.centos.org|baseurl=http://vault.centos.org|' /etc/yum.repos.d/CentOS-*.repo
+
 ARG XENONnT_TAG
 
 RUN echo "Building Docker container for XENONnT_${XENONnT_TAG} ..."


### PR DESCRIPTION
[slack thread](https://xenonnt.slack.com/archives/C016UJZ090B/p1719843208556959)

CentOS Linux 7 end of life is June 30, 2024 ([website](https://www.centos.org/)). But we have to stay with EL7 because of https://github.com/XENONnT/base_environment/issues/1697.

Then we see an error from https://github.com/XENONnT/base_environment/actions/runs/9747603708/job/26900689611, which might be solved by https://serverfault.com/a/1161831, so this PR tries it.