### PR TITLE
bump jax

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ ipykernel==6.29.5                                  # For ipywidgets
 ipympl==0.9.4                                      # For online monitoring
 ipython==8.18.1                                    # >=8.19.0 Requires-Python >=3.10
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-jax[cuda12_pip]==0.4.30
+jax==0.4.30
 jedi==0.19.1                                       
 jupyter==1.0.0
 jupyterlab==4.0.12                                 # <4.1.0 for compatibility with xeauth 0.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ ipykernel==6.29.5                                  # For ipywidgets
 ipympl==0.9.4                                      # For online monitoring
 ipython==8.18.1                                    # >=8.19.0 Requires-Python >=3.10
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-jax[cuda12_pip]==0.4.25
+jax[cuda12_pip]==0.4.30
 jedi==0.19.1                                       
 jupyter==1.0.0
 jupyterlab==4.0.12                                 # <4.1.0 for compatibility with xeauth 0.2.3


### PR DESCRIPTION
Qin needs jax>=0.4.30 to use a new position reconstruction plugin for SR2 reprocessing.