### PR TITLE
Fix utilix and straxen version for SR1

### DIFF
--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -49,7 +49,7 @@ tensorflow==2.15.0.post1
 typing-extensions==4.12.2                          # Tensorflow and bokeh dependency
 tqdm==4.66.5
 uproot==5.4.0
-utilix==0.11.0                                     # dependency for straxen, admix
+utilix==0.9.1                                      # dependency for straxen, admix
 xarray==2024.3.0                                   # xarray 2024.6.0 depends on pandas>=2.0
 xedocs==0.2.31
 zarr==2.18.2                                       # 2.18.3 Requires-Python >=3.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,7 @@ snakeviz==2.2.0
 sphinx==7.3.7                                      # higher versions require python 3.10
 statsmodels==0.14.3
 strax==1.6.5
-straxen==2.2.4
+straxen==2.2.6
 tables==3.9.2                                      # higher versions require python 3.10; pytables, necessary for pandas hdf5 i/o
 tensorflow-probability==0.24.0
 timeout_decorator==0.5.0                           # needed by fuse


### PR DESCRIPTION
The motivation is to keep backward compatibility to lower `straxen` version in a branch. Similar to https://github.com/XENONnT/straxen/tree/sr1_leftovers.