### PR TITLE
Update rframe, xedocs, strax, straxen, cutax

### DIFF
--- a/.github/workflows/test_and_update.yml
+++ b/.github/workflows/test_and_update.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   release:
     types: [created]
-  pull_request:
+  # pull_request:
   push:
     branches:
       - master

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN yum-config-manager --disable Pegasus
 
 RUN yum -y clean all && yum -y --skip-broken upgrade
 
-RUN  yum -y install centos-release-scl && \
+RUN yum -y install centos-release-scl && \
     sed -i.bak 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
     sed -i.bak 's|#.*baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
     yum -y install \
@@ -65,8 +65,7 @@ RUN source /opt/rh/devtoolset-9/enable && \
     rm -f create-env conda_xnt.yml
 
 # relax permissions so we can build cvmfs tar balls
-RUN mkdir -p /cvmfs
-RUN chmod 1777 /cvmfs
+RUN mkdir -p /cvmfs && chmod 1777 /cvmfs
 
 COPY labels.json /.singularity.d/
 

--- a/create-env
+++ b/create-env
@@ -8,7 +8,7 @@ gfal2_bindings_version=1.12.2
 gfal2_util_version=1.8.1
 rucio_version=32.8.0
 ## REMEMBER THE 'v' IN CUTAX_VERSION!! (unless it is 'latest')
-cutax_version=v1.19.5
+cutax_version=v2.0.0
 #######################################################################
 
 set -e

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -42,7 +42,7 @@ pymongo==3.13.0                                    # don't upgrade it
 pytest==8.3.4
 pytest-cov==6.0.0
 pytest-xdist==3.6.1
-rframe==0.2.21
+rframe==0.2.22
 scikit-learn==1.2.2                                # don't update
 scipy==1.13.1                                      # 1.14.0 Requires-Python >=3.10
 tensorflow==2.15.0.post1
@@ -51,6 +51,6 @@ tqdm==4.67.1
 uproot==5.5.1
 utilix==0.11.0                                     # dependency for straxen, admix
 xarray==2024.3.0                                   # xarray 2024.6.0 depends on pandas>=2.0
-xedocs==0.2.34
+xedocs==0.2.36
 zarr==2.18.2                                       # 2.18.3 Requires-Python >=3.10
 zstd==1.5.6.1                                      # strax dependency

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,8 +50,8 @@ sharedarray==3.2.4
 snakeviz==2.2.2
 sphinx==7.3.7                                      # higher versions require python 3.10
 statsmodels==0.14.4
-strax==2.0.4
-straxen==3.0.2
+strax==2.0.5
+straxen==3.0.3
 tables==3.9.2                                      # higher versions require python 3.10; pytables, necessary for pandas hdf5 i/o
 tensorflow-probability==0.25.0
 timeout_decorator==0.5.0                           # needed by fuse


### PR DESCRIPTION
The PR to fully remove CMT and fully use python 3.10