### PR TITLE
Remove Python bytecode files from target directory

### DIFF
--- a/create-env
+++ b/create-env
@@ -247,7 +247,14 @@ for space in /project/lgrandi/grid_proxy /project2/lgrandi/grid_proxy /xenon/gri
             export X509_USER_PROXY=\${space}/xenon_service_proxy
         fi
         # change where we cache the .pyc files if we are on one of these sites.
-        export PYTHONPYCACHEPREFIX=/tmp/\$USER
+        for base in /scratch/midway3/$USER /scratch/midway2/$USER /scratch/dali/$USER "$HOME/.cache"; do
+            if [ -d "$base" ] && [ -w "$base" ]; then
+                export PYTHONPYCACHEPREFIX="$base/pycache_xenonnt"
+                mkdir -p "$PYTHONPYCACHEPREFIX"
+                break
+            fi
+        done
+
     fi
 done
 

--- a/create-env
+++ b/create-env
@@ -325,5 +325,10 @@ if [ "x\$XENON_DEBUG" != "x" ]; then
 fi
 EOF
 
+announce "Removing packaged Python bytecode"
+find ${target_dir}/anaconda -type d -name __pycache__ -prune -exec rm -rf {} +
+find ${target_dir}/anaconda -type f -name '*.pyc' -delete
+find ${target_dir}/anaconda -type f -name '*.pyo' -delete
+
 # Done testing
 announce "All done!"


### PR DESCRIPTION
Fix for: EOFError: marshal data too short



This pull request improves how Python bytecode cache files are handled in the environment setup script. It introduces a more robust and site-aware mechanism for setting the `PYTHONPYCACHEPREFIX` location and adds cleanup steps to remove packaged Python bytecode from the Anaconda installation.

Improvements to Python bytecode cache handling:

* The script now dynamically selects the most appropriate writable cache directory for `PYTHONPYCACHEPREFIX`, preferring `/scratch/midway3/$USER`, `/scratch/midway2/$USER`, `/scratch/dali/$USER`, or falling back to `$HOME/.cache`, and creates the directory if it does not exist.

Cleanup of packaged Python bytecode:

* After environment setup, the script removes all `__pycache__` directories and `.pyc`/`.pyo` files from the Anaconda installation to ensure a clean environment.