### PR TITLE
several changes to make geant4 and ROOT to work

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@
 !requirements.txt
 !create-env
 !conda_xnt.yml
+!thisroot.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ RUN dnf -y install \
     &&\
     dnf clean all
 
-ADD create-env conda_xnt.yml requirements.txt /tmp/
+ADD create-env conda_xnt.yml requirements.txt thisroot.sh /tmp/
 
 COPY extra_requirements/requirements-tests.txt /tmp/extra_requirements/requirements-tests.txt
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5555410.svg)](https://doi.org/10.5281/zenodo.5555410)
 [![Test and update contexts](https://github.com/XENONnT/base_environment/actions/workflows/test_and_update.yml/badge.svg)](https://github.com/XENONnT/base_environment/actions/workflows/test_and_update.yml)
 
-Base software environment for XENONnT, including Python 3 and data management tools.
+Base software environment for XENONnT, including Python 3, ROOT, Geant4 and data management tools.
 
 Please see [this page on the XENON wiki](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon%3Axenonnt%3Acomputing%3Abaseenvironment) for more details.
 
@@ -11,13 +11,14 @@ The resulting environment is available as:
 
 * **Singularity image under CVMFS.** This can be used in interactive enviroments as well as OSG compute jobs
   The location is `/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-xenon:{version}`. Source
-  `/opt/XENONnT/setup.sh` to get the environment configured.
+  `/opt/XENONnT/setup.sh` to get Python, ROOT, Geant4 and data-management tools configured.
 * **Source-able environment under CVMFS.** This is mostly useful in interactive enviroments like Midway. Note
   that it assumes you are on a EL7 based host. The location is
   `/cvmfs/xenon.opensciencegrid.org/releases/nT/{version}` and each version contains a `setup.sh` script
   you can source to get the environment.
 * **Docker image in DockerHub**. This version can be useful if you want to extend the base_environment, or
-  use the environment for example on your laptop. The location is `opensciencegrid/osgvo-xenon:{version}`
+  use the environment for example on your laptop. The location is `opensciencegrid/osgvo-xenon:{version}`.
+  Source `/opt/XENONnT/setup.sh` inside the container to configure Python, ROOT and Geant4.
 * **Singularity images available on https**. This version is experimental. The
   location is `https://xenon.isi.edu/images/`
   
@@ -34,7 +35,6 @@ in XENONnT is that the `create-env` script is run in a Docker container. The bui
 taking place twice: once to build the Docker container with a deployment under
 `/opt/XENONnT`, and once to build the tarball for the CVMFS deployment under
 `/cvmfs/xenon.opensciencegrid.org/releases/nT/`.
-
 
 
 

--- a/create-env
+++ b/create-env
@@ -341,15 +341,32 @@ export PATH=$target_dir/bin:$PATH
 
 announce "Installing ROOT"
 cd /tmp
-rm -rf /tmp/root
+rm -rf /opt/root
 wget -nv -O root_v${root_version}.Linux-almalinux8.10-x86_64-gcc8.5.tar.gz \
     https://root.cern/download/root_v${root_version}.Linux-almalinux8.10-x86_64-gcc8.5.tar.gz
-tar xzf root_v${root_version}.Linux-almalinux8.10-x86_64-gcc8.5.tar.gz -C /tmp
-mv /tmp/root ${target_dir}/root
+tar xzf root_v${root_version}.Linux-almalinux8.10-x86_64-gcc8.5.tar.gz -C /opt
+mv /opt/root ${target_dir}/root
 rm -f root_v${root_version}.Linux-almalinux8.10-x86_64-gcc8.5.tar.gz
 
+announce "Installing custom ROOT setup"
+thisroot_source=
+if [ -f ./thisroot.sh ]; then
+    thisroot_source=./thisroot.sh
+elif [ -f /tmp/thisroot.sh ]; then
+    thisroot_source=/tmp/thisroot.sh
+fi
+
+if [ "x$thisroot_source" = "x" ]; then
+    echo "ERROR: custom thisroot.sh not found; refusing to use ROOT's default thisroot.sh" >&2
+    exit 1
+fi
+
+mkdir -p ${target_dir}/bin
+sed "s;^ROOTSYS=.*;ROOTSYS=${target_dir}/root;" "$thisroot_source" > ${target_dir}/bin/thisroot.sh
+chmod +x ${target_dir}/bin/thisroot.sh
+
 # Ensure ROOT works
-. ${target_dir}/root/bin/thisroot.sh
+. ${target_dir}/bin/thisroot.sh
 installed_root_version=$(root-config --version | tr '/' '.')
 if [ "$installed_root_version" != "$root_version" ]; then
     echo "Unexpected ROOT version: $installed_root_version" >&2
@@ -376,34 +393,41 @@ cmake -DCMAKE_INSTALL_PREFIX=$target_dir \
       /tmp/geant4.${geant4_version}
 make -j8
 make install
+
+# Geant4 10.06 still exports -std=c++11 in geant4make/geant4-config on EL8.
+sed -i 's/-std=c++11/-std=c++17/g' "${target_dir}/bin/geant4-config"
+sed -i 's/-std=c++11/-std=c++17/g' "${target_dir}"/share/Geant4-*/geant4make/config/sys/Linux-g++.gmk
+sed -i 's/-std=c++11/-std=c++17/g' "${target_dir}"/lib*/Geant4-*/Geant4Config.cmake
+
+# Fail early if the install still exports C++11
+if "${target_dir}/bin/geant4-config" --cflags | grep -q -- '-std=c++11'; then
+    echo "ERROR: Installed Geant4 still exports -std=c++11" >&2
+    exit 1
+fi
+
 cd /tmp
 rm -rf geant4.${geant4_version}.tar.gz geant4.${geant4_version}
 
 announce "Adding ROOT/Geant4 setup"
-cat > ${target_dir}/bin/thisroot.sh <<EOF
-#!/bin/bash
-. ${target_dir}/root/bin/thisroot.sh
-export CLING_STANDARD_PCH=none
-EOF
-chmod +x ${target_dir}/bin/thisroot.sh
 
-# Source MC env on container start
-cat > /.singularity.d/env/zzz-60-xenon-montecarlo.sh <<EOF
+cat >> ${target_dir}/setup.sh <<EOF
 
-#!/bin/sh
-if [ "x\$XENON_DEBUG" != "x" ]; then
-    echo
-    env
-    echo
-fi
-if [ \$XENON_SOURCE -eq 1 ]; then
-    START_DIR=\$PWD
-    cd ${target_dir}/bin
-    . ./thisroot.sh
-    . ./geant4.sh
-    cd ${target_dir}/share/Geant4-*/geant4make/
-    . ./geant4make.sh
-    cd \$START_DIR
+# ROOT / Geant4
+if [ -f ${target_dir}/bin/thisroot.sh ] && [ -f ${target_dir}/bin/geant4.sh ]; then
+    XENON_START_DIR=\$PWD
+    . ${target_dir}/bin/thisroot.sh
+    . ${target_dir}/bin/geant4.sh
+
+    for XENON_GEANT4MAKE_DIR in ${target_dir}/share/Geant4-*/geant4make; do
+        if [ -f "\$XENON_GEANT4MAKE_DIR/geant4make.sh" ]; then
+            cd "\$XENON_GEANT4MAKE_DIR"
+            . ./geant4make.sh
+            break
+        fi
+    done
+
+    cd "\$XENON_START_DIR"
+    unset XENON_START_DIR XENON_GEANT4MAKE_DIR
 fi
 EOF
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requires = open_requirements('extra_requirements/requirements-tests.txt')
 setuptools.setup(
     name='base_environment',
     version='2026.04.1',
-    description='Base software environment for XENONnT, including python and data management tools',
+    description='Base software environment for XENONnT, including Python, ROOT, Geant4 and data management tools',
     author='base_environment contributors, the XENON collaboration',
     url='https://github.com/XENONnT/base_environment',
     long_description=readme,

--- a/thisroot.sh
+++ b/thisroot.sh
@@ -153,7 +153,7 @@ if [ -n "${ROOTSYS}" ] ; then
 fi
 
 
-ROOTSYS=/opt/geant4
+ROOTSYS=/opt/XENONnT/root
 export ROOTSYS
 
 


### PR DESCRIPTION
## Summary (from Codex)

This PR folds ROOT and Geant4 setup into `base_environment` more explicitly and ensures the custom `thisroot.sh` is used instead of ROOT’s default setup script.

## Changes

- Install ROOT under `${target_dir}/root`, e.g. `/opt/XENONnT/root` in the Docker image.
- Move the custom `thisroot.sh` template from `bin/thisroot.sh` to repo-root `thisroot.sh`.
- Copy `thisroot.sh` into the Docker build context via the Dockerfile.
- During `create-env`, install the custom `thisroot.sh` into `${target_dir}/bin/thisroot.sh`, rewriting `ROOTSYS` to `${target_dir}/root`.
- Fail the build if the custom `thisroot.sh` cannot be found, avoiding a silent fallback to ROOT’s default script.
- Verify ROOT by sourcing the installed custom `${target_dir}/bin/thisroot.sh` and checking `root-config --version`.
- Move ROOT/Geant4 runtime setup into `${target_dir}/setup.sh`, so Docker, Singularity, and CVMFS source-able environments share the same setup path.
- Update README/setup metadata to mention ROOT and Geant4 as part of the base environment.