### PR TITLE
fix: geant4.sh location error

### DIFF
--- a/create-env
+++ b/create-env
@@ -415,7 +415,9 @@ cat >> ${target_dir}/setup.sh <<EOF
 if [ -f ${target_dir}/bin/thisroot.sh ] && [ -f ${target_dir}/bin/geant4.sh ]; then
     XENON_START_DIR=\$PWD
     . ${target_dir}/bin/thisroot.sh
-    . ${target_dir}/bin/geant4.sh
+
+    cd ${target_dir}/bin
+    . ./geant4.sh
 
     for XENON_GEANT4MAKE_DIR in ${target_dir}/share/Geant4-*/geant4make; do
         if [ -f "\$XENON_GEANT4MAKE_DIR/geant4make.sh" ]; then


### PR DESCRIPTION
## Summary

Fix Geant4 environment activation in `base_environment`.

The generated Geant4 setup script, `geant4.sh`, can fail to self-locate when it is sourced by absolute path from `/opt/XENONnT/setup.sh`. This can happen when entering the container with `apptainer shell`, producing:

```text
ERROR: geant4.sh could NOT self-locate Geant4 installation