### PR TITLE
update some dependencies from dependant bot suggestion

### DIFF
--- a/create-env
+++ b/create-env
@@ -524,5 +524,14 @@ find ${target_dir}/anaconda -type d -name __pycache__ -prune -exec rm -rf {} +
 find ${target_dir}/anaconda -type f -name '*.pyc' -delete
 find ${target_dir}/anaconda -type f -name '*.pyo' -delete
 
+# Install additional packages
+announce "Installing additional Python packages: xenon-plot-style"
+cd ${target_dir}
+git clone https://github.com/XENONnT/xenon_plot_style.git
+cd xenon_plot_style
+pip install .
+cd ${target_dir}
+rm -rf xenon_plot_style
+
 # Done testing
 announce "All done!"

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -8,12 +8,12 @@ coveralls==4.0.1
 dask==2025.1.0
 dask-jobqueue==0.8.5
 datashader==0.17.0
-deepdiff==8.4.2
+deepdiff==8.6.2
 dill==0.3.9                                        # strax dependency
 docutils==0.18.1                                   # don't update, straxen dependency
 flake8==7.1.1
 fsspec==2025.2.0
-GitPython==3.1.44                                  # pegasus dependency
+GitPython==3.1.50                                  # pegasus dependency
 graphviz==0.20.3
 holoviews==1.18.3                                  # don't update, conflicts with xeauth 
 hypothesis==6.124.9
@@ -22,7 +22,7 @@ ipywidgets==8.1.5                                  # for online monitoring
 jax==0.5.0
 Jinja2==3.1.5
 jupyter-client==8.6.3
-keras==3.8.0
+keras==3.13.2
 lz4==4.4.3                                         # strax dependency
 m2r==0.2.1                                         # don't update, straxen dependency
 matplotlib==3.9.4
@@ -38,9 +38,9 @@ packaging==24.2
 pandas==2.2.3
 panel==1.2.3                                       # upgrading it causes conflict with xeauth
 psutil==5.9.8                                      # upgrading it causes conflict with jupyter-resource-usage
-pyarrow==19.0.0
+pyarrow==23.0.1
 pymongo==3.13.0                                    # don't upgrade it
-pytest==8.3.4
+pytest==9.0.3
 pytest-cov==6.0.0
 pytest-xdist==3.6.1
 rframe==0.2.25
@@ -55,6 +55,7 @@ uproot==5.5.1
 utilix==0.12.1                                     # dependency for straxen, admix
 xarray==2025.1.2
 xedocs==0.2.44
+xenon_plot_style
 zarr==2.18.4
 zstandard==0.23.0                                  # strax dependency
 zstd==1.5.6.2                                      # strax dependency

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -1,4 +1,4 @@
-awkward==2.7.4
+awkward==2.9.1
 blosc==1.11.2                                      # strax dependency
 bokeh==3.2.2                                       # panel 1.2.3 depends on bokeh<3.3.0 and >=3.1.1
 boltons==24.1.0
@@ -35,7 +35,7 @@ npshmex==0.2.1                                     # strax dependency
 numba==0.61.0                                      # strax dependency
 numexpr==2.10.2
 packaging==24.2
-pandas==2.2.3
+pandas==2.3.3
 panel==1.2.3                                       # upgrading it causes conflict with xeauth
 psutil==5.9.8                                      # upgrading it causes conflict with jupyter-resource-usage
 pyarrow==23.0.1
@@ -50,12 +50,11 @@ setuptools==69.5.1
 tensorflow==2.18.0
 tf-keras==2.18.0
 typing-extensions==4.12.2                          # tensorflow and bokeh dependency
-tqdm==4.67.1
-uproot==5.5.1
+tqdm==4.68.2
+uproot==5.7.4
 utilix==0.12.1                                     # dependency for straxen, admix
-xarray==2025.1.2
+xarray==2026.4.0
 xedocs==0.2.44
-xenon_plot_style
 zarr==2.18.4
 zstandard==0.23.0                                  # strax dependency
-zstd==1.5.6.2                                      # strax dependency
+zstd==1.5.7.3                                      # strax dependency

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,8 +52,8 @@ strax==2.2.2
 straxen==3.2.8
 tables==3.10.2
 timeout_decorator==0.5.0                           # needed by fuse
-uncertainties==3.2.3
+uncertainties==3.2.3  
+xenon-fuse==1.6.3                                  # install fuse by default
 xe-admix==1.0.15
 xe-outsource==0.4.5
-xenon-fuse==1.6.3                                  # install fuse by default
 xgboost==3.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,4 +56,4 @@ uncertainties==3.2.3
 xenon-fuse==1.6.3                                  # install fuse by default
 xe-admix==1.0.15
 xe-outsource==0.4.5
-xgboost==3.1.3
+xgboost==3.2.0


### PR DESCRIPTION
This pull request updates several Python package dependencies in `extra_requirements/requirements-tests.txt` to newer versions and adds a step to install the `xenon-plot-style` package in the environment setup script. These changes help keep the testing environment up-to-date and ensure compatibility with recent package releases.

Dependency updates:

* Updated multiple dependencies to their latest versions, including `awkward`, `deepdiff`, `GitPython`, `keras`, `pandas`, `pyarrow`, `pytest`, `tqdm`, `uproot`, `xarray`, and `zstd` in `extra_requirements/requirements-tests.txt` to improve compatibility and incorporate bug fixes.

Environment setup improvements:

* Modified the `create-env` script to clone, install, and remove the `xenon-plot-style` package, ensuring this custom plotting style is available in the environment.