### PR TITLE
rucio update to 35.8.0

### DIFF
--- a/create-env
+++ b/create-env
@@ -5,7 +5,7 @@
 
 gfal2_bindings_version=1.12.2
 gfal2_util_version=1.8.1
-rucio_version=32.8.0
+rucio_version=35.8.0
 ## REMEMBER THE 'v' IN CUTAX_VERSION!! (unless it is 'latest')
 cutax_version=v2.3.7
 nestpy_version=v2.0.4

--- a/create-env
+++ b/create-env
@@ -168,9 +168,9 @@ cd rucio
 # For some strange reason `git checkout $rucio_version` does not work 2022/07/22
 git checkout $rucio_version -f
 # dependency of rucio-clients
-grep -E '^dogpile\.cache' requirements.txt | cut -d' ' -f1 | xargs pip install --prefix=${target_dir}/anaconda/envs/${env_name}
-grep -E '^tabulate' requirements.txt | cut -d' ' -f1 | xargs pip install --prefix=${target_dir}/anaconda/envs/${env_name}
-python setup_rucio_client.py install --prefix=${target_dir}/anaconda/envs/${env_name}
+grep -E '^dogpile-cache' requiments/requirements.client.txt | cut -d' ' -f1 | xargs pip install --prefix=${target_dir}/anaconda/envs/${env_name}
+grep -E '^tabulate' requiments/requirements.client.txt | cut -d' ' -f1 | xargs pip install --prefix=${target_dir}/anaconda/envs/${env_name}
+
 cd ${target_dir}
 rm -rf rucio
 

--- a/create-env
+++ b/create-env
@@ -168,8 +168,8 @@ cd rucio
 # For some strange reason `git checkout $rucio_version` does not work 2022/07/22
 git checkout $rucio_version -f
 # dependency of rucio-clients
-grep -E '^dogpile-cache' requiments/requirements.client.txt | cut -d' ' -f1 | xargs pip install --prefix=${target_dir}/anaconda/envs/${env_name}
-grep -E '^tabulate' requiments/requirements.client.txt | cut -d' ' -f1 | xargs pip install --prefix=${target_dir}/anaconda/envs/${env_name}
+grep -E '^dogpile-cache' requirements/requirements.client.txt | cut -d' ' -f1 | xargs pip install --prefix=${target_dir}/anaconda/envs/${env_name}
+grep -E '^tabulate' requirements/requirements.client.txt | cut -d' ' -f1 | xargs pip install --prefix=${target_dir}/anaconda/envs/${env_name}
 
 cd ${target_dir}
 rm -rf rucio

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -49,7 +49,7 @@ scipy==1.15.1
 setuptools==83.0.0
 tensorflow==2.18.0
 tf-keras==2.18.0
-typing-extensions==4.160                          # tensorflow bokeh and rucio-client dependency
+typing-extensions==4.16.0                          # tensorflow bokeh and rucio-client dependency
 tqdm==4.68.2
 uproot==5.7.4
 utilix==0.12.1                                     # dependency for straxen, admix

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -46,10 +46,10 @@ pytest-xdist==3.6.1
 rframe==0.2.25
 scikit-learn==1.6.1                                # don't update
 scipy==1.15.1
-setuptools==78.1.1
+setuptools==83.0.0
 tensorflow==2.18.0
 tf-keras==2.18.0
-typing-extensions==4.12.2                          # tensorflow and bokeh dependency
+typing-extensions==4.160                          # tensorflow bokeh and rucio-client dependency
 tqdm==4.68.2
 uproot==5.7.4
 utilix==0.12.1                                     # dependency for straxen, admix

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ poetry==2.0.1
 pydantic==1.10.14                                  # rframe needs pydantic<2.0.0
 pytest-runner==6.0.1
 reprox==0.2.2
-requests==2.31.0                                   # rucio-clients 32.8.0 requires requests<=2.31.0
+requests==2.34.2                                   # rucio-clients 35.8.0 requires requests>=2.32.3
 seaborn==0.13.2
 simple-slurm==0.3.5
 sharedarray==3.2.4


### PR DESCRIPTION
This pull request updates the Rucio dependency version in the `create-env` file.

* Updated the `rucio_version` from `32.8.0` to `35.8.0` to ensure compatibility with the server version.